### PR TITLE
Changed from global add_definitions(TEMPLATES_IN_HEADERS VISTLE_IMPL)

### DIFF
--- a/vistle/CMakeLists.txt
+++ b/vistle/CMakeLists.txt
@@ -47,10 +47,6 @@ if (VISTLE_DOUBLE_PRECISION)
 endif()
 
 option(TEMPLATES_IN_HEADERS "define templates in headers" ON)
-if(${TEMPLATES_IN_HEADERS})
-   add_definitions(-DTEMPLATES_IN_HEADERS)
-   add_definitions(-DVISTLE_IMPL)
-endif()
 
 macro(USE_OPENMP)
    if (OPENMP_FOUND)

--- a/vistle/core/CMakeLists.txt
+++ b/vistle/core/CMakeLists.txt
@@ -173,6 +173,11 @@ vistle_add_library(vistle_core ${VISTLE_LIB_TYPE} ${core_SOURCES} ${core_HEADERS
 vistle_export_library(vistle_core ${VISTLE_LIB_TYPE} ${core_SOURCES} ${core_HEADERS})
 #vistle_install_headers(core ${core_HEADERS})
 
+if(${TEMPLATES_IN_HEADERS})
+   target_compile_definitions(vistle_core PUBLIC -DTEMPLATES_IN_HEADERS)
+   target_compile_definitions(vistle_core PUBLIC -DVISTLE_IMPL)
+endif()
+
 if(UNIX AND NOT APPLE)
 	target_link_libraries(vistle_core
         PUBLIC -lrt

--- a/vistle/insitu/core/CMakeLists.txt
+++ b/vistle/insitu/core/CMakeLists.txt
@@ -18,7 +18,8 @@ set(HEADER
 vistle_add_library(vistle_insitu_core ${SOURCES} ${HEADER})
 vistle_export_library(vistle_insitu_core ${SOURCES} ${HEADER})
 vistle_target_link_libraries(vistle_insitu_core 
-	PUBLIC vistle_core
+	PRIVATE vistle_util
+    PUBLIC  vistle_core 
 	PRIVATE Boost::boost
     PRIVATE Boost::serialization
     PRIVATE MPI::MPI_C

--- a/vistle/insitu/libsim/CMakeLists.txt
+++ b/vistle/insitu/libsim/CMakeLists.txt
@@ -116,6 +116,12 @@ endif()
 
 vistle_add_library(${LIBNAME} ${RUNTIME_HEADERS} ${RUNTIME_SOURCES})
 vistle_export_library(${LIBNAME} ${RUNTIME_HEADERS} ${RUNTIME_SOURCES})
+
+if(${TEMPLATES_IN_HEADERS})
+   target_compile_definitions(${LIBNAME} PRIVATE -DTEMPLATES_IN_HEADERS)
+endif()
+
+
 vistle_target_link_libraries(${LIBNAME}
 		PRIVATE vistle_insitu_core
 		PRIVATE vistle_module

--- a/vistle/module/CMakeLists.txt
+++ b/vistle/module/CMakeLists.txt
@@ -22,6 +22,11 @@ use_openmp()
 vistle_add_library(vistle_module ${VISTLE_LIB_TYPE} ${module_SOURCES} ${module_HEADERS})
 vistle_export_library(vistle_module ${VISTLE_LIB_TYPE} ${module_SOURCES} ${module_HEADERS})
 
+if(${TEMPLATES_IN_HEADERS})
+   target_compile_definitions(vistle_module PRIVATE -DTEMPLATES_IN_HEADERS)
+   target_compile_definitions(vistle_module PRIVATE -DVISTLE_IMPL)
+endif()
+
 if(UNIX AND NOT APPLE)
 	vistle_target_link_libraries(vistle_module
         PRIVATE -lrt

--- a/vistle/util/CMakeLists.txt
+++ b/vistle/util/CMakeLists.txt
@@ -54,7 +54,9 @@ vistle_add_library(vistle_util ${VISTLE_LIB_TYPE} ${util_SOURCES} ${util_HEADERS
 vistle_export_library(vistle_util ${VISTLE_LIB_TYPE} ${util_SOURCES} ${util_HEADERS})
 
 target_include_directories(vistle_util SYSTEM PRIVATE ${BOTAN_INCLUDE_DIRS})
-
+if(${TEMPLATES_IN_HEADERS})
+   target_compile_definitions(vistle_util PUBLIC -DTEMPLATES_IN_HEADERS)
+endif()
 vistle_target_link_libraries(vistle_util
     PRIVATE Boost::system
 	PUBLIC Boost::filesystem


### PR DESCRIPTION
to local target_compile_definitions so that project that import vistle libraries also have this set correctly