### PR TITLE
Module compounds

### DIFF
--- a/lib/vistle/control/hub.cpp
+++ b/lib/vistle/control/hub.cpp
@@ -1925,6 +1925,27 @@ void Hub::clearStatus()
     m_statusText.clear();
 }
 
+int Hub::getParentCompound(int modId)
+{
+    if (!Id::isModule(modId))
+        return Id::Invalid;
+    auto modName = m_stateTracker.getModuleName(modId);
+    for (size_t i = modId - 1; i >= message::Id::ModuleBase; --i) {
+        auto modit = m_stateTracker.runningMap.find(i);
+        if (modit != m_stateTracker.runningMap.end()) {
+            auto &av = m_stateTracker.getStaticModuleInfo(modit->first);
+        if (av.isCompound()) {
+                if (av.submodules().size() >= modId - i && av.submodules()[modId - i - 1].name == modName)
+                    return modit->first;
+            else
+                    break;
+        }
+        }
+    }
+    return Id::Invalid;
+}
+
+
 bool Hub::connectToMaster(const std::string &host, unsigned short port)
 {
     assert(!m_isMaster);

--- a/lib/vistle/control/hub.h
+++ b/lib/vistle/control/hub.h
@@ -169,6 +169,8 @@ private:
     bool handlePriv(const message::Cover &cover, const buffer *payload);
     bool handlePriv(const message::ModuleExit &exit);
     bool handlePriv(const message::Spawn &spawn);
+    bool handlePriv(const message::Kill &kill);
+
     template<typename ConnMsg>
     bool handleConnectOrDisconnect(const ConnMsg &mm)
     {
@@ -213,6 +215,7 @@ private:
     void setStatus(const std::string &s, message::UpdateStatus::Importance prio = message::UpdateStatus::Low);
     void clearStatus();
     int getParentCompound(int modId);
+    void killSubmodules(int modId, const AvailableModule &av);
     std::map<int, std::vector<message::Buffer>> m_sendAfterSpawn;
 
 #if BOOST_VERSION >= 106600

--- a/lib/vistle/control/hub.h
+++ b/lib/vistle/control/hub.h
@@ -212,7 +212,7 @@ private:
     void setSessionUrl(const std::string &url);
     void setStatus(const std::string &s, message::UpdateStatus::Importance prio = message::UpdateStatus::Low);
     void clearStatus();
-
+    int getParentCompound(int modId);
     std::map<int, std::vector<message::Buffer>> m_sendAfterSpawn;
 
 #if BOOST_VERSION >= 106600

--- a/lib/vistle/control/hub.h
+++ b/lib/vistle/control/hub.h
@@ -168,6 +168,9 @@ private:
     bool handlePriv(const message::ModuleExit &exit);
     bool handlePriv(const message::Spawn &spawn);
 
+    void spawnModule(message::Spawn &spawn);
+    bool spawnModuleCompound(const message::Spawn &spawn);
+
     bool checkChildProcesses(bool emergency = false);
     bool hasChildProcesses(bool ignoreGui = false);
     void emergencyQuit();

--- a/lib/vistle/control/hub.h
+++ b/lib/vistle/control/hub.h
@@ -47,6 +47,8 @@ public:
     bool sendUi(const message::Message &msg, int id = message::Id::Broadcast, const buffer *payload = nullptr);
     bool sendModule(const message::Message &msg, int id, const buffer *payload = nullptr);
     bool sendAll(const message::Message &msg, const buffer *payload = nullptr);
+    bool sendAllUi(const message::Message &msg, const buffer *payload = nullptr);
+    bool sendAllButUi(const message::Message &msg, const buffer *payload = nullptr);
 
     const StateTracker &stateTracker() const;
     StateTracker &stateTracker();
@@ -170,6 +172,7 @@ private:
 
     void spawnModule(message::Spawn &spawn);
     bool spawnModuleCompound(const message::Spawn &spawn);
+    void handleMirrorConnect(const message::Connect, std::function<bool(const message::Connect &)> sendFunc);
 
     bool checkChildProcesses(bool emergency = false);
     bool hasChildProcesses(bool ignoreGui = false);

--- a/lib/vistle/control/hub.h
+++ b/lib/vistle/control/hub.h
@@ -172,7 +172,6 @@ private:
 
     void spawnModule(message::Spawn &spawn);
     bool spawnModuleCompound(const message::Spawn &spawn);
-    void handleMirrorConnect(const message::Connect, std::function<bool(const message::Connect &)> sendFunc);
 
     bool checkChildProcesses(bool emergency = false);
     bool hasChildProcesses(bool ignoreGui = false);

--- a/lib/vistle/control/vistle.py
+++ b/lib/vistle/control/vistle.py
@@ -305,6 +305,9 @@ def moduleCompoundAddModule(compoundId, moduleName, x, y):
 def moduleCompoundConnect(compoundId, fromId, fromName, toId, toName): #if fromId or toId is equal to compound id the port is exposed with the given name
    _vistle.moduleCompoundConnect(compoundId, fromId, fromName, toId, toName)
 
+def moduleCompoundExpose(compoundId, compoundPortName, modId, modPortName):
+   _vistle.moduleCompoundExpose(compoundId, compoundPortName, modId, modPortName)
+
 def moduleCompoundCommit(compoundId):
    _vistle.moduleCompoundCommit(compoundId)
 

--- a/lib/vistle/control/vistle.py
+++ b/lib/vistle/control/vistle.py
@@ -296,8 +296,8 @@ def load(filename = None):
 def loadScript(filename):
    _vistle.loadScript(filename)
 
-def moduleCompoundAlloc(compoundName):
-   return _vistle.moduleCompoundAlloc(compoundName)
+def moduleCompoundCreate(compoundName):
+   return _vistle.moduleCompoundCreate(compoundName)
 
 def moduleCompoundAddModule(compoundId, moduleName, x, y):
    return _vistle.moduleCompoundAddModule(compoundId, moduleName, x, y)
@@ -305,8 +305,8 @@ def moduleCompoundAddModule(compoundId, moduleName, x, y):
 def moduleCompoundConnect(compoundId, fromId, fromName, toId, toName): #if fromId or toId is equal to compound id the port is exposed with the given name
    _vistle.moduleCompoundConnect(compoundId, fromId, fromName, toId, toName)
 
-def moduleCompoundCreate(compoundId):
-   _vistle.moduleCompoundCreate(compoundId)
+def moduleCompoundCommit(compoundId):
+   _vistle.moduleCompoundCommit(compoundId)
 
 def setRelativePos(moduleId, x, y):
    _vistle.setRelativePos(moduleId, x, y)

--- a/lib/vistle/control/vistle.py
+++ b/lib/vistle/control/vistle.py
@@ -299,14 +299,17 @@ def loadScript(filename):
 def moduleCompoundCreate(compoundName):
    return _vistle.moduleCompoundCreate(compoundName)
 
+def moduleCompoundSetPath(compoundId, path):
+   _vistle.moduleCompoundSetPath(compoundId, path)
+
 def moduleCompoundAddModule(compoundId, moduleName, x, y):
    return _vistle.moduleCompoundAddModule(compoundId, moduleName, x, y)
 
 def moduleCompoundConnect(compoundId, fromId, fromName, toId, toName): #if fromId or toId is equal to compound id the port is exposed with the given name
    _vistle.moduleCompoundConnect(compoundId, fromId, fromName, toId, toName)
 
-def moduleCompoundExpose(compoundId, compoundPortName, modId, modPortName):
-   _vistle.moduleCompoundExpose(compoundId, compoundPortName, modId, modPortName)
+def moduleCompoundExpose(compoundId, compoundPortName, modId, modPortName, portType):
+   _vistle.moduleCompoundExpose(compoundId, compoundPortName, modId, modPortName, portType)
 
 def moduleCompoundCommit(compoundId):
    _vistle.moduleCompoundCommit(compoundId)
@@ -415,3 +418,4 @@ Message = _vistle.Message
 StateObserver = _vistle.StateObserver
 Text = _vistle.Text
 Status = _vistle.Status
+PortType = _vistle.PortType

--- a/lib/vistle/core/availablemodule.cpp
+++ b/lib/vistle/core/availablemodule.cpp
@@ -174,6 +174,11 @@ bool ModuleCompound::send(const sendShmMessageFunction &func) const
     return AvailableModuleBase::send(message::Type::CREATEMODULECOMPOUND, func);
 }
 
+void ModuleCompound::setPath(const std::string &path)
+{
+    m_path = path;
+}
+
 AvailableModule ModuleCompound::transform()
 {
     return AvailableModule{std::move(*this)};

--- a/lib/vistle/core/availablemodule.h
+++ b/lib/vistle/core/availablemodule.h
@@ -87,13 +87,13 @@ public:
     const std::set<Connection> connections() const;
 
 protected:
+    std::string m_path;
     bool send(message::Type type, const sendMessageFunction &func) const;
     bool send(message::Type type, const sendShmMessageFunction &func) const;
 
 private:
     int m_hub;
     std::string m_name;
-    std::string m_path;
     std::string m_description;
 
 
@@ -130,6 +130,7 @@ public:
     using AvailableModuleBase::AvailableModuleBase;
     bool send(const sendMessageFunction &func) const;
     bool send(const sendShmMessageFunction &func) const;
+    void setPath(const std::string &path);
     AvailableModule transform(); //this invalidates this object;
 };
 typedef std::map<AvailableModule::Key, AvailableModule> AvailableMap;

--- a/lib/vistle/core/messages.cpp
+++ b/lib/vistle/core/messages.cpp
@@ -808,87 +808,44 @@ const char *AddObjectCompleted::originalDestPort() const
     return m_orgDestPort.data();
 }
 
-Connect::Connect(const int moduleIDA, const std::string &portA, const int moduleIDB, const std::string &portB)
+ConnectBase::ConnectBase(const int moduleIDA, const std::string &portA, const int moduleIDB, const std::string &portB)
 : moduleA(moduleIDA), moduleB(moduleIDB)
 {
     COPY_STRING(portAName, portA);
     COPY_STRING(portBName, portB);
 }
 
-const char *Connect::getPortAName() const
+const char *ConnectBase::getPortAName() const
 {
     return portAName.data();
 }
 
-const char *Connect::getPortBName() const
+const char *ConnectBase::getPortBName() const
 {
     return portBName.data();
 }
 
-void Connect::setModuleA(int id)
+void ConnectBase::setModuleA(int id)
 {
     moduleA = id;
 }
 
-int Connect::getModuleA() const
+int ConnectBase::getModuleA() const
 {
     return moduleA;
 }
 
-void Connect::setModuleB(int id)
+void ConnectBase::setModuleB(int id)
 {
     moduleB = id;
 }
 
-int Connect::getModuleB() const
+int ConnectBase::getModuleB() const
 {
     return moduleB;
 }
 
-void Connect::reverse()
-{
-    std::swap(moduleA, moduleB);
-    std::swap(portAName, portBName);
-}
-
-Disconnect::Disconnect(const int moduleIDA, const std::string &portA, const int moduleIDB, const std::string &portB)
-: moduleA(moduleIDA), moduleB(moduleIDB)
-{
-    COPY_STRING(portAName, portA);
-    COPY_STRING(portBName, portB);
-}
-
-const char *Disconnect::getPortAName() const
-{
-    return portAName.data();
-}
-
-const char *Disconnect::getPortBName() const
-{
-    return portBName.data();
-}
-
-void Disconnect::setModuleA(int id)
-{
-    moduleA = id;
-}
-
-int Disconnect::getModuleA() const
-{
-    return moduleA;
-}
-
-void Disconnect::setModuleB(int id)
-{
-    moduleB = id;
-}
-
-int Disconnect::getModuleB() const
-{
-    return moduleB;
-}
-
-void Disconnect::reverse()
+void ConnectBase::reverse()
 {
     std::swap(moduleA, moduleB);
     std::swap(portAName, portBName);

--- a/lib/vistle/core/messages.h
+++ b/lib/vistle/core/messages.h
@@ -435,51 +435,41 @@ private:
     port_name_t m_orgDestPort;
 };
 
+//! Base class for connect and disconnect
+
+class V_COREEXPORT ConnectBase {
+public:
+    ConnectBase(const int moduleIDA, const std::string &portA, const int moduleIDB, const std::string &portB);
+
+    const char *getPortAName() const;
+    const char *getPortBName() const;
+
+    void setModuleA(int id);
+    int getModuleA() const;
+    void setModuleB(int id);
+    int getModuleB() const;
+
+    void reverse(); //! swap source and destination
+
+private:
+    port_name_t portAName;
+    port_name_t portBName;
+
+    int moduleA;
+    int moduleB;
+};
+
 //! connect an output port to an input port of another module
-class V_COREEXPORT Connect: public MessageBase<Connect, CONNECT> {
-public:
-    Connect(const int moduleIDA, const std::string &portA, const int moduleIDB, const std::string &portB);
-
-    const char *getPortAName() const;
-    const char *getPortBName() const;
-
-    void setModuleA(int id);
-    int getModuleA() const;
-    void setModuleB(int id);
-    int getModuleB() const;
-
-    void reverse(); //! swap source and destination
-
-private:
-    port_name_t portAName;
-    port_name_t portBName;
-
-    int moduleA;
-    int moduleB;
+class V_COREEXPORT Connect: public MessageBase<Connect, CONNECT>, public ConnectBase {
+    using ConnectBase::ConnectBase;
 };
-
+static_assert(sizeof(Connect) <= Message::MESSAGE_SIZE, "message too large");
 //! disconnect an output port from an input port of another module
-class V_COREEXPORT Disconnect: public MessageBase<Disconnect, DISCONNECT> {
-public:
-    Disconnect(const int moduleIDA, const std::string &portA, const int moduleIDB, const std::string &portB);
-
-    const char *getPortAName() const;
-    const char *getPortBName() const;
-
-    void setModuleA(int id);
-    int getModuleA() const;
-    void setModuleB(int id);
-    int getModuleB() const;
-
-    void reverse(); //! swap source and destination
-
-private:
-    port_name_t portAName;
-    port_name_t portBName;
-
-    int moduleA;
-    int moduleB;
+class V_COREEXPORT Disconnect: public MessageBase<Disconnect, DISCONNECT>, public ConnectBase {
+    using ConnectBase::ConnectBase;
 };
+static_assert(sizeof(Disconnect) <= Message::MESSAGE_SIZE, "message too large");
+
 
 //! notification that a module has created a parameter
 class V_COREEXPORT AddParameter: public MessageBase<AddParameter, ADDPARAMETER> {

--- a/lib/vistle/core/statetracker.cpp
+++ b/lib/vistle/core/statetracker.cpp
@@ -873,26 +873,6 @@ bool StateTracker::handlePriv(const message::Started &started)
     return true;
 }
 
-bool StateTracker::handleConnect(const message::Connect &connect)
-{
-    if (!handlePriv(connect)) {
-        // to be queued by caller
-        //m_queue.emplace_back(connect);
-        return false;
-    }
-    return true;
-}
-
-bool StateTracker::handleDisconnect(const message::Disconnect &disconnect)
-{
-    if (!handlePriv(disconnect)) {
-        // to be queued by caller
-        //m_queue.emplace_back(disconnect);
-        return false;
-    }
-    return true;
-}
-
 bool StateTracker::handlePriv(const message::Connect &connect)
 {
     if (isExecuting(connect.getModuleA()) || isExecuting(connect.getModuleB()))

--- a/lib/vistle/core/statetracker.cpp
+++ b/lib/vistle/core/statetracker.cpp
@@ -1826,6 +1826,17 @@ void StateTracker::updateStatus()
     }
 }
 
+const AvailableModule &StateTracker::getStaticModuleInfo(int modId)
+{
+    auto hubId = getHub(modId);
+    if (hubId != Id::Invalid) {
+        auto it = availableModules().find({hubId, getModuleName(modId)});
+        if (it != availableModules().end())
+            return it->second;
+    }
+    throw vistle::exception{"getStaticModuleInfo failed mor module with id " + std::to_string(modId)};
+}
+
 void StateObserver::quitRequested()
 {}
 

--- a/lib/vistle/core/statetracker.h
+++ b/lib/vistle/core/statetracker.h
@@ -223,6 +223,8 @@ protected:
     bool hasCombinePort(int id) const;
     bool isExecuting(int id) const;
 
+    void appendModuleState(VistleState &state, const Module &mod) const;
+
     std::map<AvailableModule::Key, AvailableModule> m_availableModules;
 
     std::set<StateObserver *> m_observers;

--- a/lib/vistle/core/statetracker.h
+++ b/lib/vistle/core/statetracker.h
@@ -132,8 +132,12 @@ public:
 
     bool handle(const message::Message &msg, const buffer *payload, bool track = true);
     bool handle(const message::Message &msg, const char *payload, size_t payloadSize, bool track = true);
-    bool handleConnect(const message::Connect &conn);
-    bool handleDisconnect(const message::Disconnect &disc);
+
+    template<typename ConnMsg>
+    bool handleConnectOrDisconnect(const ConnMsg &msg)
+    {
+        return handlePriv(msg);
+    }
 
     std::shared_ptr<PortTracker> portTracker() const;
 

--- a/lib/vistle/core/statetracker.h
+++ b/lib/vistle/core/statetracker.h
@@ -169,6 +169,7 @@ public:
     std::string sessionUrl() const;
 
     void printModules() const;
+    const AvailableModule &getStaticModuleInfo(int modId);
 
 protected:
     std::shared_ptr<message::Buffer> removeRequest(const message::uuid_t &uuid);

--- a/lib/vistle/manager/clustermanager.cpp
+++ b/lib/vistle/manager/clustermanager.cpp
@@ -748,6 +748,7 @@ bool ClusterManager::handle(const message::Buffer &message, const MessagePayload
         ModuleCompound comp(message, pl);
         AvailableModule::Key key(comp.hub(), comp.name());
         auto av = comp.transform();
+        av.setHub(hubId());
         av.send(std::bind(&Communicator::sendHub, &Communicator::the(), std::placeholders::_1, std::placeholders::_2));
         m_localModules[key] = std::move(av);
         break;


### PR DESCRIPTION
Create module compounds via python script or let the mapeditor write the script by selecting the modules you want to combine-> right click-> save as module group
Scripts in .config/vistle and the .vsl ending will automatically loaded when starting Vistle. Use this mechanism to permanently add your compounds to the module browser.