### PR TITLE
make ispc compilation independent from MPI and OpenMP flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,6 @@ option(VISTLE_USE_QT5 "Build GUI with Qt5 instead of Qt6" ON)
 
 option(VISTLE_COLOR_DIAGNOSTICS "Produce ANSI-colored build output (GNU/Clang)" ON)
 
-option(VISTLE_ISPC_PTHREAD_WORKAROUND "Work around problem -pthread flag being propagated to ispc" OFF)
-
 if(NOT "$ENV{VBUILD}" STREQUAL "")
     include("${PROJECT_SOURCE_DIR}/build/$ENV{VBUILD}.cmake")
 endif()
@@ -416,10 +414,6 @@ if(NOT CRAY AND NOT VISTLE_GUI_ONLY)
     add_definitions(-DOMPI_SKIP_MPICXX) # OpenMPI
     add_definitions(-DMPI_NO_CPPBIND) # HPE MPT
     vistle_find_package(MPI REQUIRED COMPONENTS C CXX)
-    # clear MPI_C_COMPILE_OPTIONS, as these will be passed to ispc and might contain -pthread, which ispc does not understand
-    if(VISTLE_ISPC_PTHREAD_WORKAROUND)
-        unset(MPI_C_COMPILE_OPTIONS CACHE)
-    endif()
 
     include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${MPI_C_COMPILE_FLAGS}>)
@@ -909,9 +903,6 @@ vistle_find_package(OpenGL)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-if(VISTLE_ISPC_PTHREAD_WORKAROUND)
-    set(THREADS_PREFER_PTHREAD_FLAG FALSE)
-endif()
 vistle_find_package(Threads REQUIRED)
 
 # do it here, so that we see the warnings just once

--- a/module/render/DisCOVERay/CMakeLists.txt
+++ b/module/render/DisCOVERay/CMakeLists.txt
@@ -56,10 +56,12 @@ include_directories(SYSTEM ${EMBREE_INCLUDE_DIRS})
 set(CMAKE_CXX_COMPILE_FLAGS "${CMAKE_CXX_COMPILE_FLAGS} ${MPI_C_COMPILE_FLAGS}")
 set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${MPI_C_LINK_FLAGS}")
 
-add_module(DisCOVERay ${description} ${RAY_HEADERS} ${RAY_SOURCES} ${ISPC_SOURCES})
+add_library(DisCOVERay_ispc OBJECT ${ISPC_HEADERS} ${ISPC_SOURCES})
+add_module(DisCOVERay ${description} ${RAY_HEADERS} ${RAY_SOURCES})
 
 target_link_libraries(
     DisCOVERay
+    DisCOVERay_ispc
     ${BOOST_MPI}
     vistle_module
     vistle_renderer


### PR DESCRIPTION
Build an intermediate object library from ISPC sources, so that
DisCOVERay's target_link_libraries does not affect ISPC objects.