### PR TITLE
clear input object cache before receiving new objects

### DIFF
--- a/lib/vistle/module/module.cpp
+++ b/lib/vistle/module/module.cpp
@@ -1801,6 +1801,7 @@ bool Module::handleExecute(const vistle::message::Execute *exec)
     busy.setDestId(Id::LocalManager);
     sendMessage(busy);
 #endif
+
     if (exec->what() == Execute::ComputeExecute || exec->what() == Execute::Prepare) {
         if (m_lastTask) {
             CERR << "prepare: waiting for previous tasks..." << std::endl;
@@ -1808,7 +1809,11 @@ bool Module::handleExecute(const vistle::message::Execute *exec)
         }
 
         applyDelayedChanges();
-
+    }
+    if (exec->what() == Execute::Prepare) {
+        m_cache.clear();
+    }
+    if (exec->what() == Execute::ComputeExecute || exec->what() == Execute::Prepare) {
         ret &= prepareWrapper(exec);
     }
 

--- a/lib/vistle/module/objectcache.cpp
+++ b/lib/vistle/module/objectcache.cpp
@@ -11,8 +11,8 @@ ObjectCache::~ObjectCache()
 
 void ObjectCache::clear()
 {
+    m_oldCache.clear();
     if (m_cacheMode == CacheDeleteLate) {
-        m_oldCache.clear();
         std::swap(m_cache, m_oldCache);
     } else {
         m_cache.clear();

--- a/lib/vistle/util/affinity.cpp
+++ b/lib/vistle/util/affinity.cpp
@@ -217,7 +217,7 @@ bool apply_affinity_from_environment(int nodeRank, int ranksOnThisNode)
               << ")" << std::endl;
     if (depth == -1) {
         std::cerr << "affinity: possible values for VISTLE_AFFINITY are "
-                  << "pu, core, chip, numa, machinee" << std::endl;
+                  << "pu, core, chip, numa, machine" << std::endl;
         return false;
     }
 


### PR DESCRIPTION
otherwise, inupt objects from several runs of upstream modules would accumulate