### PR TITLE
add missing updateFromHandle

### DIFF
--- a/lib/vistle/core/shm_array_impl.h
+++ b/lib/vistle/core/shm_array_impl.h
@@ -210,6 +210,7 @@ void shm_array<T, allocator>::resize(const size_t size, const T &value)
 template<typename T, class allocator>
 const vtkm::cont::ArrayHandle<typename shm_array<T, allocator>::handle_type> &shm_array<T, allocator>::handle() const
 {
+    updateFromHandle(); // required in order to be compatible with ArrayHandleBasic
     return m_handle;
 }
 #else

--- a/lib/vistle/core/shm_reference.h
+++ b/lib/vistle/core/shm_reference.h
@@ -345,9 +345,9 @@ public:
 
 private:
 #ifdef NO_SHMEM
+    const shm_array<T, shm_allocator<T>> *m_arr = nullptr;
     mutable std::atomic<const T *> m_data;
     mutable std::mutex m_mutex;
-    const shm_array<T, shm_allocator<T>> *m_arr = nullptr;
 #else
     const T *m_data = nullptr;
 #endif


### PR DESCRIPTION
when accesssing arrays through a ArrayHandleBasic, data has to be copied
into linear representation, if not already provided throuh setHandle