### PR TITLE
just drop ArrayHandle instead of resizing to 0

### DIFF
--- a/lib/vistle/core/shm_array.h
+++ b/lib/vistle/core/shm_array.h
@@ -250,7 +250,11 @@ void shm_array<T, allocator>::updateFromHandle(bool invalidate)
         PROF_SCOPE("shm_array::updateFromHandle()");
         m_memoryValid = true;
 
-        m_data = reinterpret_cast<T *>(m_handle.GetWritePointer());
+        if (m_capacity > 0) {
+            m_data = reinterpret_cast<T *>(m_handle.GetWritePointer());
+        } else {
+            m_data = nullptr;
+        }
     }
     if (invalidate) {
         m_unknown = vtkm::cont::UnknownArrayHandle();
@@ -272,7 +276,11 @@ void shm_array<T, allocator>::updateFromHandle(bool invalidate) const
 
     PROF_SCOPE("shm_array::updateFromHandle()const");
 
-    m_data = reinterpret_cast<T *>(m_handle.GetWritePointer());
+    if (m_capacity > 0) {
+        m_data = reinterpret_cast<T *>(m_handle.GetWritePointer());
+    } else {
+        m_data = nullptr;
+    }
 #endif
 }
 

--- a/lib/vistle/core/shm_array_impl.h
+++ b/lib/vistle/core/shm_array_impl.h
@@ -283,10 +283,15 @@ void shm_array<T, allocator>::reserve_or_shrink(const size_t capacity)
 
     PROF_SCOPE("shm_array::reserve_or_shrink()");
 #ifdef NO_SHMEM
-    updateFromHandle(true);
-    m_handle.Allocate(capacity, vtkm::CopyFlag::On);
-    m_data = reinterpret_cast<T *>(m_handle.GetWritePointer());
     m_capacity = capacity;
+    updateFromHandle(true);
+    if (capacity > 0) {
+        m_handle.Allocate(capacity, vtkm::CopyFlag::On);
+        m_data = reinterpret_cast<T *>(m_handle.GetWritePointer());
+    } else {
+        m_handle = vtkm::cont::make_ArrayHandle(static_cast<handle_type *>(nullptr), 0, vtkm::CopyFlag::Off);
+        m_data = nullptr;
+    }
 #else
     pointer new_data = capacity > 0 ? m_allocator.allocate(capacity) : nullptr;
     const size_t n = capacity < m_size ? capacity : m_size;


### PR DESCRIPTION
also avoid forcing data to GPU on destruction