### PR TITLE
gridSize to vector because dim is not constexpr

### DIFF
--- a/module/geometry/SpheresOverlap/algo/CellListsAlgorithm.cpp
+++ b/module/geometry/SpheresOverlap/algo/CellListsAlgorithm.cpp
@@ -13,7 +13,7 @@ UniformGrid::ptr CreateSearchGrid(Points::const_ptr spheres, Scalar searchRadius
     // we expect getBounds() to return a pair of Vector3s
     assert(dim == 3);
 
-    Index gridSize[dim];
+    std::vector<Index> gridSize(dim);
 
     // divide bounding box into cubes with side length = searchRadius
     for (Index i = 0; i < dim; i++) {


### PR DESCRIPTION
At least on Windows, i could be better to just set dim = 3