### PR TITLE
Propagate OpenMP include dir if vistle_core links with it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1041,12 +1041,6 @@ set(THRUST_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/lib/3rdparty/thrust")
 # new submodule for block distribution
 set(DIY_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/lib/3rdparty/diy/include")
 
-# vistle_find_package(Eigen3 REQUIRED)
-set(EIGEN3_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/lib/3rdparty")
-
-# add_definitions(-DEIGEN_DEFAULT_DENSE_INDEX_TYPE=short)
-add_definitions(-DEIGEN_DEFAULT_DENSE_INDEX_TYPE=int)
-
 if(NOT VISTLE_GUI_ONLY)
     # Boost.MPI is compiled with Vistle - for easy switching of MPI versions
     include_directories(BEFORE SYSTEM "${PROJECT_SOURCE_DIR}/lib/3rdparty/${BOOST_MPI_DIR}/include")

--- a/lib/3rdparty/CMakeLists.txt
+++ b/lib/3rdparty/CMakeLists.txt
@@ -221,5 +221,23 @@ if(VISTLE_INSTALL_3RDPARTY)
         COMPONENT Devel)
 endif()
 
+# vistle_find_package(Eigen3 REQUIRED)
+add_library(eigen INTERFACE)
+add_library(Eigen3::Eigen ALIAS eigen)
+set(EIGEN_DEFINITIONS "-DEIGEN_DEFAULT_DENSE_INDEX_TYPE=int")
+target_compile_definitions(eigen INTERFACE ${EIGEN_DEFINITIONS})
+#set(EIGEN3_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/lib/3rdparty")
+target_include_directories(eigen INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>)
+if(OpenMP_CXX_FOUND)
+    vistle_target_link_libraries(eigen INTERFACE OpenMP::OpenMP_CXX)
+endif()
+# Export as title case Eigen
+set_target_properties(eigen PROPERTIES EXPORT_NAME Eigen)
+vistle_export_library(eigen)
+
+#install (TARGETS eigen EXPORT Eigen3Targets)
+
+# add_definitions(-DEIGEN_DEFAULT_DENSE_INDEX_TYPE=short)
+
 include(cmrc/CMakeRC.cmake)
 vistle_export_library(cmrc-base)

--- a/lib/vistle/core/CMakeLists.txt
+++ b/lib/vistle/core/CMakeLists.txt
@@ -193,6 +193,7 @@ vistle_target_link_libraries(
     PUBLIC
     vtkm::cont)
 target_link_libraries(vistle_core PRIVATE vistle_config)
+target_link_libraries(vistle_core PUBLIC Eigen3::Eigen)
 
 if(ZFP_FOUND)
     target_compile_definitions(vistle_core PRIVATE HAVE_ZFP)
@@ -216,10 +217,6 @@ if(LZ4_FOUND)
     target_compile_definitions(vistle_core PRIVATE HAVE_LZ4)
     target_include_directories(vistle_core SYSTEM PRIVATE ${LZ4_INCLUDE_DIRS})
     vistle_target_link_libraries(vistle_core PRIVATE ${LZ4_LIBRARIES})
-endif()
-
-if(OpenMP_CXX_FOUND)
-    vistle_target_link_libraries(vistle_core PUBLIC OpenMP::OpenMP_CXX)
 endif()
 
 target_include_directories(vistle_core SYSTEM PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/3rdparty>)

--- a/lib/vistle/core/CMakeLists.txt
+++ b/lib/vistle/core/CMakeLists.txt
@@ -218,6 +218,10 @@ if(LZ4_FOUND)
     vistle_target_link_libraries(vistle_core PRIVATE ${LZ4_LIBRARIES})
 endif()
 
+if(OpenMP_CXX_FOUND)
+    vistle_target_link_libraries(vistle_core PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
 target_include_directories(vistle_core SYSTEM PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/3rdparty>)
 target_include_directories(vistle_core SYSTEM PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/3rdparty/yas/include>)
 if(VISTLE_INSTALL_3RDPARTY)


### PR DESCRIPTION
As `Eigen/Core` includes `omp.h`, `vistle_core` should propagate that dependency. Otherwise, if `omp.h` sits in a non-standard folder, dependent modules can't find it.