### PR TITLE
ignore socket errors while shutting down

### DIFF
--- a/app/gui/CMakeLists.txt
+++ b/app/gui/CMakeLists.txt
@@ -2,20 +2,12 @@ if(NOT Qt6_FOUND AND NOT Qt5_FOUND)
     message("Not building GUI: neither Qt5 nor Qt6 Core library found")
     return()
 endif()
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 add_subdirectory(propertybrowser)
 add_subdirectory(remotefilebrowser)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-#set(CMAKE_AUTOUIC ON)
-
-if(Python_FOUND)
-    add_definitions(-DHAVE_PYTHON)
-endif()
-
-#include_directories(${CMAKE_CURRENT_BINARY_DIR} .)
-include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/3rdparty/qt-solutions/qtpropertybrowser/src)
 
 set(gui_SOURCES
     main.cpp
@@ -72,20 +64,18 @@ if(APPLE)
     set(gui_HEADERS ${gui_SOURCES} macosutils.h)
 endif(APPLE)
 
+vistle_add_executable(${gui_name} MACOSX_BUNDLE ${gui_SOURCES})
 if(VISTLE_USE_QT5)
     qt5_wrap_ui(GUI_UI_SRCS ${gui_FORMS})
     qt5_add_resources(GUI_QRC_SOURCES gui.qrc about.qrc)
+    target_link_libraries(${gui_name} PRIVATE Qt5::Widgets)
 else()
     qt6_wrap_ui(GUI_UI_SRCS ${gui_FORMS})
     qt6_add_resources(GUI_QRC_SOURCES gui.qrc about.qrc)
-endif()
-vistle_add_executable(${gui_name} MACOSX_BUNDLE ${gui_SOURCES} ${GUI_UI_SRCS} ${GUI_QRC_SOURCES})
-if(VISTLE_USE_QT5)
-    target_link_libraries(${gui_name} PRIVATE Qt5::Widgets)
-else()
     target_link_libraries(${gui_name} PRIVATE Qt6::Widgets)
     qt_disable_unicode_defines(${gui_name})
 endif()
+target_sources(${gui_name} PRIVATE ${GUI_UI_SRCS} ${GUI_QRC_SOURCES})
 target_link_libraries(${gui_name} PRIVATE Threads::Threads)
 target_link_libraries(
     ${gui_name}
@@ -100,6 +90,7 @@ target_link_libraries(
             vistle_remotefiledialog)
 
 if(Python_FOUND)
+    target_compile_definitions(${gui_name} PRIVATE -DHAVE_PYTHON)
     target_link_libraries(${gui_name} PRIVATE Python::Python vistle_python)
 endif()
 

--- a/app/gui/CMakeLists.txt
+++ b/app/gui/CMakeLists.txt
@@ -2,17 +2,19 @@ if(NOT Qt6_FOUND AND NOT Qt5_FOUND)
     message("Not building GUI: neither Qt5 nor Qt6 Core library found")
     return()
 endif()
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_subdirectory(propertybrowser)
 add_subdirectory(remotefilebrowser)
 
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+#set(CMAKE_AUTOUIC ON)
 
 if(Python_FOUND)
     add_definitions(-DHAVE_PYTHON)
 endif()
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR} .)
+#include_directories(${CMAKE_CURRENT_BINARY_DIR} .)
 include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/3rdparty/qt-solutions/qtpropertybrowser/src)
 
 set(gui_SOURCES

--- a/app/gui/propertybrowser/CMakeLists.txt
+++ b/app/gui/propertybrowser/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(CMAKE_AUTOMOC TRUE)
-set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 set(SOURCES
     ../../../lib/3rdparty/qt-solutions/qtpropertybrowser/src/qtbuttonpropertybrowser.cpp
@@ -45,26 +44,20 @@ set(HEADERS
 
 set(FORMS)
 
+add_library(vistle_propertybrowser STATIC ${SOURCES} ${HEADERS})
 if(VISTLE_USE_QT5)
     qt5_wrap_ui(UI_SRCS ${FORMS})
+    target_link_libraries(vistle_propertybrowser PRIVATE Qt5::Widgets)
 else()
     qt6_wrap_ui(UI_SRCS ${FORMS})
+    qt_disable_unicode_defines(vistle_propertybrowser)
+    target_link_libraries(vistle_propertybrowser PRIVATE Qt6::Widgets)
 endif()
-
-add_library(vistle_propertybrowser STATIC ${SOURCES} ${UI_SRCS})
+target_sources(vistle_propertybrowser PRIVATE ${UI_SRCS})
 
 target_compile_definitions(vistle_propertybrowser PRIVATE QT_DISABLE_DEPRECATED_BEFORE=0x000000)
 
-target_include_directories(vistle_propertybrowser SYSTEM #PRIVATE ${Boost_INCLUDE_DIRS}
-                           PRIVATE ../../../lib/3rdparty/qt-solutions/qtpropertybrowser/src)
-target_include_directories(
-    vistle_propertybrowser
-    PRIVATE ../..
-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(vistle_propertybrowser SYSTEM PUBLIC ../../../lib/3rdparty/qt-solutions/qtpropertybrowser/src)
+target_include_directories(vistle_propertybrowser PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-if(VISTLE_USE_QT5)
-    target_link_libraries(vistle_propertybrowser PRIVATE ${QT_LIBRARIES} vistle_util vistle_core Qt5::Widgets)
-else()
-    target_link_libraries(vistle_propertybrowser PRIVATE ${QT_LIBRARIES} vistle_util vistle_core Qt6::Widgets)
-    qt_disable_unicode_defines(vistle_propertybrowser)
-endif()
+target_link_libraries(vistle_propertybrowser PRIVATE vistle_util vistle_core)

--- a/app/gui/propertybrowser/CMakeLists.txt
+++ b/app/gui/propertybrowser/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOMOC TRUE)
+set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 set(SOURCES
     ../../../lib/3rdparty/qt-solutions/qtpropertybrowser/src/qtbuttonpropertybrowser.cpp
@@ -44,7 +45,11 @@ set(HEADERS
 
 set(FORMS)
 
-qt_wrap_ui(UI_SRCS ${FORMS})
+if(VISTLE_USE_QT5)
+    qt5_wrap_ui(UI_SRCS ${FORMS})
+else()
+    qt6_wrap_ui(UI_SRCS ${FORMS})
+endif()
 
 add_library(vistle_propertybrowser STATIC ${SOURCES} ${UI_SRCS})
 

--- a/app/gui/remotefilebrowser/CMakeLists.txt
+++ b/app/gui/remotefilebrowser/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
+#set(CMAKE_AUTOUIC ON)
 
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
@@ -32,7 +32,11 @@ set(HEADERS
 
 set(FORMS remotefiledialog.ui)
 
-qt_wrap_ui(UI_SRCS ${FORMS})
+if(VISTLE_USE_QT5)
+    qt5_wrap_ui(UI_SRCS ${FORMS})
+else()
+    qt6_wrap_ui(UI_SRCS ${FORMS})
+endif()
 
 add_library(vistle_remotefiledialog STATIC ${SOURCES} ${UI_SRCS})
 

--- a/app/gui/remotefilebrowser/CMakeLists.txt
+++ b/app/gui/remotefilebrowser/CMakeLists.txt
@@ -1,7 +1,4 @@
 set(CMAKE_AUTOMOC ON)
-#set(CMAKE_AUTOUIC ON)
-
-set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 set(SOURCES
     remotefiledialog.cpp
@@ -32,26 +29,23 @@ set(HEADERS
 
 set(FORMS remotefiledialog.ui)
 
+add_library(vistle_remotefiledialog STATIC ${SOURCES} ${HEADERS})
+
 if(VISTLE_USE_QT5)
     qt5_wrap_ui(UI_SRCS ${FORMS})
-else()
-    qt6_wrap_ui(UI_SRCS ${FORMS})
-endif()
-
-add_library(vistle_remotefiledialog STATIC ${SOURCES} ${UI_SRCS})
-
-target_compile_definitions(vistle_remotefiledialog PRIVATE QT_DISABLE_DEPRECATED_BEFORE=0x000000)
-
-target_include_directories(vistle_remotefiledialog SYSTEM PRIVATE ../../../3rdparty/qt-solutions/qtpropertybrowser/src)
-target_include_directories(
-    vistle_remotefiledialog
-    PRIVATE ../..
-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-target_link_libraries(vistle_remotefiledialog PRIVATE vistle_util vistle_core)
-if(VISTLE_USE_QT5)
     target_link_libraries(vistle_remotefiledialog PRIVATE Qt5::Widgets)
 else()
+    qt6_wrap_ui(UI_SRCS ${FORMS})
     target_link_libraries(vistle_remotefiledialog PRIVATE Qt6::Widgets)
     qt_disable_unicode_defines(vistle_remotefiledialog)
 endif()
+target_sources(vistle_remotefiledialog PRIVATE ${UI_SRCS})
+
+target_compile_definitions(vistle_remotefiledialog PRIVATE QT_DISABLE_DEPRECATED_BEFORE=0x000000)
+
+target_include_directories(
+    vistle_remotefiledialog
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(vistle_remotefiledialog PRIVATE vistle_util vistle_core)

--- a/app/gui/remotefilebrowser/qsidebar.cpp
+++ b/app/gui/remotefilebrowser/qsidebar.cpp
@@ -48,8 +48,8 @@
 #include <qevent.h>
 #include <qdebug.h>
 #include "remotefileiconprovider.h"
-#include <remotefiledialog.h>
-#include <abstractfilesystemmodel.h>
+#include "remotefiledialog.h"
+#include "abstractfilesystemmodel.h"
 
 QT_BEGIN_NAMESPACE
 

--- a/lib/vistle/control/hub.h
+++ b/lib/vistle/control/hub.h
@@ -261,6 +261,8 @@ private:
     std::map<vistle::message::AddHub, std::future<bool>> m_outstandingDataConnections;
 
     std::unique_ptr<PythonInterpreter> m_python;
+
+    void initiateQuit();
 };
 
 } // namespace vistle

--- a/lib/vistle/core/tcpmessage.cpp
+++ b/lib/vistle/core/tcpmessage.cpp
@@ -27,6 +27,13 @@ typedef uint32_t SizeType;
 
 static const size_t buffersize = 16384;
 
+static bool silentErrors = false;
+
+void prepare_shutdown()
+{
+    silentErrors = true;
+}
+
 #ifndef NDEBUG
 namespace {
 
@@ -466,9 +473,11 @@ bool send(socket_t &sock, const message::Message &msg, error_code &ec, const cha
 
     asio::write(sock, buffers, ec);
     if (ec) {
-        std::cerr << "message::send: error: " << ec.message() << std::endl;
-        if (ec != boost::system::errc::connection_reset)
-            std::cerr << backtrace() << std::endl;
+        if (!silentErrors) {
+            std::cerr << "message::send: " << msg << ", error: " << ec.message() << std::endl;
+            if (ec != boost::system::errc::connection_reset)
+                std::cerr << backtrace() << std::endl;
+        }
         return false;
     }
 

--- a/lib/vistle/core/tcpmessage.h
+++ b/lib/vistle/core/tcpmessage.h
@@ -41,6 +41,7 @@ void V_COREEXPORT return_buffer(std::shared_ptr<buffer> &buf);
 std::shared_ptr<buffer> V_COREEXPORT get_buffer(size_t size = 0);
 
 bool V_COREEXPORT clear_request_queue();
+void V_COREEXPORT prepare_shutdown();
 
 } // namespace message
 } // namespace vistle

--- a/lib/vistle/net/dataproxy.cpp
+++ b/lib/vistle/net/dataproxy.cpp
@@ -682,9 +682,12 @@ bool DataProxy::connectRemoteData(const message::AddHub &remote)
             if (ec) {
                 CERR << "cancelling operations on socket failed: " << ec.message() << std::endl;
             } else {
+                bool open = s->is_open();
                 s->close(ec);
                 if (ec) {
-                    CERR << "closing socket failed: " << ec.message() << std::endl;
+                    if (open) {
+                        CERR << "closing socket failed: " << ec.message() << std::endl;
+                    }
                 }
             }
         }

--- a/lib/vistle/util/threadname.cpp
+++ b/lib/vistle/util/threadname.cpp
@@ -9,11 +9,33 @@
 #include <iostream>
 #endif
 
+#include <array>
+
 #ifdef __APPLE__
 #include <pthread.h>
 #endif
 
 namespace vistle {
+
+std::string getThreadName()
+{
+    std::array<char, 100> name;
+#ifdef __linux
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12
+
+    int err = pthread_getname_np(pthread_self(), name.data(), name.size());
+    if (err == 0) {
+        return name.data();
+    }
+    std::cerr << "getThreadName failed: " << strerror(err) << std::endl;
+#endif
+#endif
+
+#ifdef __APPLE__
+    pthread_getname_np(pthread_self(), name.data(), name.size());
+#endif
+    return name.data();
+}
 
 bool setThreadName(std::string name)
 {

--- a/lib/vistle/util/threadname.h
+++ b/lib/vistle/util/threadname.h
@@ -7,5 +7,6 @@
 namespace vistle {
 
 V_UTILEXPORT bool setThreadName(std::string name);
-}
+V_UTILEXPORT std::string getThreadName();
+} // namespace vistle
 #endif

--- a/lib/vistle/util/tools.cpp
+++ b/lib/vistle/util/tools.cpp
@@ -12,12 +12,14 @@
 #endif
 
 #include "tools.h"
+#include "threadname.h"
 
 namespace vistle {
 
 std::string backtrace()
 {
     std::stringstream str;
+    str << "thread " << getThreadName() << "\n";
 
 #ifdef HAVE_EXECINFO
     const int MaxFrames = 32;


### PR DESCRIPTION
Due to the asynchronous message sending it will inevitably happen that
some messages cannot be delivered anymore, when a session is shut down:
sockets will be already be closed, because the listening process has
already terminated.

closes: #49