### PR TITLE
ensure that opencover::config::Access is configured correctly

### DIFF
--- a/module/render/COVER/COVER.cpp
+++ b/module/render/COVER/COVER.cpp
@@ -217,6 +217,9 @@ COVER::COVER(const std::string &name, int moduleId, mpi::communicator comm): vis
     } else {
         m_config.reset(
             new opencover::config::Access(configAccess()->hostname(), configAccess()->cluster(), comm.rank()));
+        if (auto covisedir = getenv("COVISEDIR")) {
+            m_config->setPrefix(covisedir);
+        }
     }
     m_coverConfigBridge.reset(new CoverConfigBridge(this));
     m_config->setWorkspaceBridge(m_coverConfigBridge.get());


### PR DESCRIPTION
configure it with equal parameters, no matter if initialized from Vistle
module or from mpicover library