### PR TITLE
update isovalue when interacting via point, whenever useful

### DIFF
--- a/example/test-workflow.vsl
+++ b/example/test-workflow.vsl
@@ -1,6 +1,11 @@
 # /usr/bin/env vistle
 # this is a Python workflow from Vistle 2024.2-d40e4a11
 
+import os
+
+# this map uses sample data from covise
+covisedir = os.getenv("COVISEDIR")
+
 MasterHub=getMasterHub()
 VistleSession=getVistleSession()
 WorkflowConfig=getWorkflowConfig()
@@ -123,7 +128,7 @@ applyParameters(mThicken12)
 
 mReadCoviseDirectory13 = waitForSpawn(umReadCoviseDirectory13)
 setVectorParam(mReadCoviseDirectory13, '_position', -386.06313522218716, -1322.5070800781252, True)
-setStringParam(mReadCoviseDirectory13, 'directory', '/home/hpcsmalh/Software/covise/share/covise/example-data/tutorial', True)
+setStringParam(mReadCoviseDirectory13, 'directory', covisedir + '/share/covise/example-data/tutorial', True)
 setStringParam(mReadCoviseDirectory13, 'grid', 'tiny_geo', True)
 setStringParam(mReadCoviseDirectory13, 'field0', 'tiny_p', True)
 setStringParam(mReadCoviseDirectory13, 'field1', 'tiny_velocity', True)
@@ -176,7 +181,7 @@ applyParameters(mFlattenTriangles21)
 
 mReadVtk22 = waitForSpawn(umReadVtk22)
 setVectorParam(mReadVtk22, '_position', 273.3315271092212, -1312.2627665602317, True)
-setStringParam(mReadVtk22, 'filename', '/home/hpcsmalh/Software/covise/share/covise/example-data/ReadVTK/unstructuredGrid.pvd', True)
+setStringParam(mReadVtk22, 'filename', covisedir + '/share/covise/example-data/ReadVTK/unstructuredGrid.pvd', True)
 setStringParam(mReadVtk22, 'point_field_0', 'pointData', True)
 setStringParam(mReadVtk22, 'point_field_1', '(NONE)', True)
 setStringParam(mReadVtk22, 'point_field_2', '(NONE)', True)

--- a/lib/vistle/core/parametermanager.h
+++ b/lib/vistle/core/parametermanager.h
@@ -115,7 +115,7 @@ public:
     int id() const;
     void setName(const std::string &name);
 
-    void applyDelayedChanges();
+    bool applyDelayedChanges();
 
 private:
     bool parameterChangedWrapper(const Parameter *p); //< wrapper to prevent recursive calls to parameterChanged
@@ -132,6 +132,7 @@ private:
     };
     std::map<std::string, ParameterData> m_parameters;
     bool m_inParameterChanged = false;
+    bool m_inApplyDelayedChanges = false;
     std::map<std::string, const Parameter *> m_delayedChanges;
 
     std::deque<message::SetParameter> m_queue;

--- a/module/map/IsoSurface/IsoSurface.cpp
+++ b/module/map/IsoSurface/IsoSurface.cpp
@@ -189,8 +189,9 @@ bool IsoSurface::reduce(int timestep)
         valRank = boost::mpi::all_reduce(comm(), valRank, boost::mpi::minimum<int>());
         if (valRank < m_size) {
             boost::mpi::broadcast(comm(), value, valRank);
-            if (m_pointOrValue->getValue() == PointInFirstStep)
+            if (m_pointOrValue->getValue() == PointInFirstStep || numTimesteps() <= 1) {
                 setParameter(m_isovalue, (Float)value);
+            }
         }
         m_performedPointSearch = true;
     }

--- a/module/test/IsoSurfaceVtkm/IsoSurfaceVtkm.cpp
+++ b/module/test/IsoSurfaceVtkm/IsoSurfaceVtkm.cpp
@@ -144,8 +144,9 @@ bool IsoSurfaceVtkm::reduce(int timestep)
         valRank = boost::mpi::all_reduce(comm(), valRank, boost::mpi::minimum<int>());
         if (valRank < m_size) {
             boost::mpi::broadcast(comm(), value, valRank);
-            if (m_pointOrValue->getValue() == PointInFirstStep)
+            if (m_pointOrValue->getValue() == PointInFirstStep || numTimesteps() <= 1) {
                 setParameter(m_isovalue, (Float)value);
+            }
         }
         m_performedPointSearch = true;
     }


### PR DESCRIPTION
also update isovalue, when selecting isosurface from location in each
timestep individually, if there is only a single timestep in the dataset

closes #197