### PR TITLE
change check in bounds_valid s.t. it behaves correctly even if m_min or m_max is NaN

### DIFF
--- a/lib/vistle/core/celltreenode.h
+++ b/lib/vistle/core/celltreenode.h
@@ -85,6 +85,12 @@ bool operator>=(const CelltreeNode<IndexSize, NumDimensions> &n0, const Celltree
 }
 
 template<size_t IndexSize, int NumDimensions>
+bool operator!=(const CelltreeNode<IndexSize, NumDimensions> &n0, const CelltreeNode<IndexSize, NumDimensions> &n1)
+{
+    return n0.start != n1.start;
+}
+
+template<size_t IndexSize, int NumDimensions>
 std::ostream &operator<<(std::ostream &os, const CelltreeNode<IndexSize, NumDimensions> &n)
 {
     os << "(" << n.start << "+" << n.size << "/" << n.dim << " -> " << n.child << ")";

--- a/lib/vistle/core/shm_array.h
+++ b/lib/vistle/core/shm_array.h
@@ -159,16 +159,10 @@ public:
         updateFromHandle();
         return m_data[0];
     }
-    bool empty() const
-    {
-        return m_size == 0;
-    }
+    bool empty() const { return m_size == 0; }
     void clear();
 
-    size_t size() const
-    {
-        return m_size;
-    }
+    size_t size() const { return m_size; }
     void resize(const size_t size);
     void resize(const size_t size, const T &value);
 
@@ -178,17 +172,16 @@ public:
     bool exact() const;
     size_t dimensionHint(int d) const;
 
-    size_t capacity() const
-    {
-        return m_capacity;
-    }
+    size_t capacity() const { return m_capacity; }
     void reserve(const size_t new_capacity);
     void reserve_or_shrink(const size_t capacity);
     void shrink_to_fit();
 
     bool bounds_valid() const
     {
-        return m_max >= m_min;
+        // this behaves wrong if either is set to NaN
+        // return m_max >= m_min;
+        return m_min != std::numeric_limits<value_type>::max() && m_max != std::numeric_limits<value_type>::lowest();
     }
     void invalidate_bounds();
     void update_bounds();

--- a/lib/vistle/core/shm_array.h
+++ b/lib/vistle/core/shm_array.h
@@ -159,10 +159,16 @@ public:
         updateFromHandle();
         return m_data[0];
     }
-    bool empty() const { return m_size == 0; }
+    bool empty() const
+    {
+        return m_size == 0;
+    }
     void clear();
 
-    size_t size() const { return m_size; }
+    size_t size() const
+    {
+        return m_size;
+    }
     void resize(const size_t size);
     void resize(const size_t size, const T &value);
 
@@ -172,7 +178,10 @@ public:
     bool exact() const;
     size_t dimensionHint(int d) const;
 
-    size_t capacity() const { return m_capacity; }
+    size_t capacity() const
+    {
+        return m_capacity;
+    }
     void reserve(const size_t new_capacity);
     void reserve_or_shrink(const size_t capacity);
     void shrink_to_fit();

--- a/lib/vistle/core/shm_array.h
+++ b/lib/vistle/core/shm_array.h
@@ -186,11 +186,14 @@ public:
     void reserve_or_shrink(const size_t capacity);
     void shrink_to_fit();
 
+    // checks if the bounds have already been set
     bool bounds_valid() const
     {
-        // this behaves wrong if either is set to NaN
-        // return m_max >= m_min;
-        return m_min != std::numeric_limits<value_type>::max() && m_max != std::numeric_limits<value_type>::lowest();
+        // The bounds have been set, if either the min or the max value is NaN.
+        if ((m_min != m_min) || (m_max != m_max))
+            return true;
+
+        return m_max >= m_min;
     }
     void invalidate_bounds();
     void update_bounds();


### PR DESCRIPTION
If m_min or m_max is NaN the assert in setHandle ("assert(m_size == 0 || bounds_valid());") fails causing Vistle to crash. This happens for some cutting planes when using VTK-m' Slice filter and computing the normals.
This patch adjusts the check in bounds_valid().