### PR TITLE
don't scatter particles across all ranks

### DIFF
--- a/app/gui/uicontroller.cpp
+++ b/app/gui/uicontroller.cpp
@@ -281,11 +281,29 @@ bool UiController::init()
     // restore default handler for Ctrl-C
     signal(SIGINT, SIG_DFL);
 
+    m_mainWindow->dataFlowView()->setFocusProxy(m_mainWindow->moduleBrowser());
+    m_mainWindow->moduleBrowser()->setFocus();
+
+    m_mainWindow->installEventFilter(this);
+
     return true;
 }
 
 UiController::~UiController()
 {}
+
+bool UiController::eventFilter(QObject *object, QEvent *event)
+{
+    if (object == m_mainWindow && event->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        if (keyEvent->key() == Qt::Key_Escape) {
+            m_mainWindow->dataFlowView()->setFocus();
+            return true;
+        } else
+            return false;
+    }
+    return false;
+}
 
 void UiController::finish()
 {

--- a/app/gui/uicontroller.h
+++ b/app/gui/uicontroller.h
@@ -29,6 +29,8 @@ public:
     bool init();
     void finish();
 
+    bool eventFilter(QObject *object, QEvent *event) override;
+
 signals:
     void visibleModuleMessage(int id, int type, QString message);
 

--- a/lib/vistle/net/dataproxy.cpp
+++ b/lib/vistle/net/dataproxy.cpp
@@ -660,7 +660,7 @@ bool DataProxy::connectRemoteData(const message::AddHub &remote)
     timer.expires_from_now(boost::posix_time::seconds(connection_timeout));
     timer.async_wait([this, hubId, connectingSockets](const boost::system::error_code &ec) {
         if (ec == asio::error::operation_aborted) {
-            // timer was cancelled
+            // timer was canceled
             return;
         }
         if (ec) {

--- a/lib/vistle/renderer/renderer.cpp
+++ b/lib/vistle/renderer/renderer.cpp
@@ -66,8 +66,6 @@ bool Renderer::needsSync(const message::Message &m) const
     case REPLAYFINISHED:
     case COVER:
         return true;
-    case ADDOBJECT:
-        return objectReceivePolicy() != ObjectReceivePolicy::Local;
     default:
         return false;
     }

--- a/module/general/Cache/Cache.cpp
+++ b/module/general/Cache/Cache.cpp
@@ -136,7 +136,7 @@ bool Cache::compute()
             if (m_toDisk) {
                 assert(m_fd != -1);
 
-                // serialialize object and all not-yet-serialized sub-objects to memory
+                // serialize object and all not-yet-serialized sub-objects to memory
                 vecostreambuf<buffer> memstr;
                 vistle::oarchive memar(memstr);
                 memar.setCompressionSettings(m_compressionSettings);

--- a/module/map/Tracer/Particle.cpp
+++ b/module/map/Tracer/Particle.cpp
@@ -25,8 +25,8 @@ Particle::Particle(Index id, int rank, Index startId, const Vector3 &pos, bool f
 , m_x(pos)
 , m_xold(pos)
 , m_v(Vector3(std::numeric_limits<Scalar>::max(), 0, 0))
-, // keep large enough so that particle moves initially
-m_p(0)
+// keep large enough so that particle moves initially
+, m_p(0)
 , m_stp(0)
 , m_time(0)
 , m_dist(0)

--- a/module/map/Tracer/Tracer.cpp
+++ b/module/map/Tracer/Tracer.cpp
@@ -33,7 +33,7 @@ DEFINE_ENUM_WITH_STRING_CONVERSIONS(StartStyle, (Line)(Plane)(Cylinder))
 
 DEFINE_ENUM_WITH_STRING_CONVERSIONS(TraceDirection, (Both)(Forward)(Backward))
 
-DEFINE_ENUM_WITH_STRING_CONVERSIONS(ParticlePlacement, (InitialRank)(RankById))
+DEFINE_ENUM_WITH_STRING_CONVERSIONS(ParticlePlacement, (InitialRank)(RankById)(RankByTimestep)(Rank0))
 
 template<class Value>
 bool agree(const boost::mpi::communicator &comm, const Value &value)
@@ -143,8 +143,8 @@ Tracer::Tracer(const std::string &name, int moduleID, mpi::communicator comm): M
         addIntParameter("num_active", "number of particles to trace simultaneously on each node (0: no. of cores)", 0);
     setParameterRange(num_active, (Integer)0, (Integer)10000);
 
-    m_particlePlacement = addIntParameter("particle_placement", "where a particle's data shall be collected", RankById,
-                                          Parameter::Choice);
+    m_particlePlacement = addIntParameter("particle_placement", "where a particle's data shall be collected",
+                                          RankByTimestep, Parameter::Choice);
     V_ENUM_SET_CHOICES(m_particlePlacement, ParticlePlacement);
 
     auto modulus = addIntParameter("cell_index_modulus", "modulus for cell number output", -1);
@@ -506,12 +506,25 @@ bool Tracer::reduce(int timestep)
     }
 
     // create particles
-    bool initialrank = m_particlePlacement->getValue() == InitialRank;
+    bool rankById = m_particlePlacement->getValue() == RankById;
     Index id = 0;
     for (int t = 0; t < numtime; ++t) {
         if (timestep != t && timestep != -1)
             continue;
         Index numblocks = size_t(t) + 1 >= grid_in.size() ? 0 : grid_in[t + 1].size();
+
+        int rank = -1;
+        switch (m_particlePlacement->getValue()) {
+        case InitialRank:
+            rank = -1;
+            break;
+        case Rank0:
+            rank = 0;
+            break;
+        case RankByTimestep:
+            rank = t % size();
+            break;
+        }
 
         //create BlockData objects
         global.blocks[t].resize(numblocks + numconstant);
@@ -531,7 +544,8 @@ bool Tracer::reduce(int timestep)
         allParticles.reserve(allParticles.size() + numparticles);
         Index i = 0;
         for (; i < numpoints; i++) {
-            int rank = initialrank ? -1 : i % size();
+            if (rankById)
+                rank = i % size();
             if (traceDirection != Backward) {
                 allParticles.emplace_back(new Particle(id++, rank, i, startpoints[i], true, global, t));
             }


### PR DESCRIPTION
Default to collect all particles corresponding to a single timestep on
one rank. Should avoid too many small objects, as more geometry will be
handled in a single batch.