### PR TITLE
unify finding Python with COVISE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,7 @@ if(NOT VISTLE_GUI_ONLY)
         endif()
     endif()
 
+    set(Python_FIND_FRAMEWORK LAST)
     vistle_find_package(Python COMPONENTS Interpreter Development REQUIRED)
     if(Python_FOUND)
         message("Found Python version ${Python_VERSION}")

--- a/lib/3rdparty/CMakeLists.txt
+++ b/lib/3rdparty/CMakeLists.txt
@@ -222,8 +222,9 @@ if(NOT VISTLE_GUI_ONLY)
     #
     # pybind11
     #
-    set(PythonLibsNew_FIND_REQUIRED FALSE)
-    set(PythonLibsNew_FOUND TRUE)
+    set(PYBIND11_FINDPYTHON
+        TRUE
+        CACHE BOOL "")
     add_subdirectory(pybind11)
 endif()
 


### PR DESCRIPTION
- use FindPython for both lib and interpreter instead of FindPythonLibs
    and FindPythonInterp
- on macos, use Python.framework only as a last resort
- do the same in COVISE, so that importing coGRMsg here works