### PR TITLE
Support both vtkm release and patch

### DIFF
--- a/module/geometry/SpheresOverlap/CMakeLists.txt
+++ b/module/geometry/SpheresOverlap/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(VISTLE_INTERNAL_VTKM)
+    add_definitions(-DVISTLE_INTERNAL_VTKM_ON)
+endif()
+
 set(HEADERS SpheresOverlap.h algo/CellListsAlgorithm.h algo/ThicknessDeterminer.h algo/VtkmSpheresOverlap.h algo/worklet/PointLocatorCellLists.h
             algo/worklet/OverlapDetector.h)
 

--- a/module/geometry/SpheresOverlap/CMakeLists.txt
+++ b/module/geometry/SpheresOverlap/CMakeLists.txt
@@ -1,5 +1,5 @@
-if(VISTLE_INTERNAL_VTKM)
-    add_definitions(-DVISTLE_INTERNAL_VTKM_ON)
+if(NOT VISTLE_INTERNAL_VTKM)
+    add_definitions(-DVISTLE_EXTERNAL_VTKM)
 endif()
 
 set(HEADERS SpheresOverlap.h algo/CellListsAlgorithm.h algo/ThicknessDeterminer.h algo/VtkmSpheresOverlap.h algo/worklet/PointLocatorCellLists.h

--- a/module/geometry/SpheresOverlap/algo/worklet/PointLocatorCellLists.h
+++ b/module/geometry/SpheresOverlap/algo/worklet/PointLocatorCellLists.h
@@ -1,15 +1,33 @@
 #ifndef POINT_LOCATOR_CELL_LISTS_H
 #define POINT_LOCATOR_CELL_LISTS_H
 
+#include <vtkm/Version.h>
+
+// Note that the version macros are only defined if find_package is called, which is
+// not the the case if Vistle builds VTK-m, i.e., VISTLE_INTERNAL_VTKM is defined.
+#define VTKM_CONTAINS_CLANG_COMPILER_PATCH \
+    ((defined(VISTLE_INTERNAL_VTKM_ON)) || (VTKM_VERSION_MAJOR > 2) || \
+     (VTKM_VERSION_MAJOR == 2 && VTKM_VERSION_MINOR > 2) || \
+     (VTKM_VERSION_MAJOR == 2 && VTKM_VERSION_MINOR == 2 && VTKM_VERSION_PATCH > 0))
+
+#if VISTLE_INTERNAL_VTKM_ON
 #include <vtkm/cont/PointLocatorBase.h>
+#else
+#include <vtkm/cont/internal/PointLocatorBase.h>
+#endif
 
 #include <vistle/core/scalar.h>
 
 #include "OverlapDetector.h"
 #include "../ThicknessDeterminer.h"
 
+#if VISTLE_INTERNAL_VTKM_ON
 class PointLocatorCellLists: public vtkm::cont::PointLocatorBase {
     using Superclass = vtkm::cont::PointLocatorBase;
+#else
+class PointLocatorCellLists: public vtkm::cont::internal::PointLocatorBase<PointLocatorCellLists> {
+    using Superclass = vtkm::cont::internal::PointLocatorBase<PointLocatorCellLists>;
+#endif
 
 public:
     void SetRadii(const vtkm::cont::UnknownArrayHandle &radii)
@@ -27,12 +45,27 @@ public:
         }
     }
 
-    void SetThicknessDeterminer(ThicknessDeterminer determiner) { this->Determiner = determiner; }
+    void SetThicknessDeterminer(ThicknessDeterminer determiner)
+    {
+        this->Determiner = determiner;
+    }
 
-    const vtkm::Vec3f &GetMinPoint() const { return this->Min; }
-    const vtkm::Vec3f &GetMaxPoint() const { return this->Max; }
-    const vtkm::Id3 &GetNumberOfBins() const { return this->Dims; }
-    const vtkm::FloatDefault &GetSearchRadius() const { return this->SearchRadius; }
+    const vtkm::Vec3f &GetMinPoint() const
+    {
+        return this->Min;
+    }
+    const vtkm::Vec3f &GetMaxPoint() const
+    {
+        return this->Max;
+    }
+    const vtkm::Id3 &GetNumberOfBins() const
+    {
+        return this->Dims;
+    }
+    const vtkm::FloatDefault &GetSearchRadius() const
+    {
+        return this->SearchRadius;
+    }
 
     VTKM_CONT
     OverlapDetector PrepareForExecution(vtkm::cont::DeviceAdapterId device, vtkm::cont::Token &token) const;

--- a/module/geometry/SpheresOverlap/algo/worklet/PointLocatorCellLists.h
+++ b/module/geometry/SpheresOverlap/algo/worklet/PointLocatorCellLists.h
@@ -10,7 +10,7 @@
      (VTKM_VERSION_MAJOR == 2 && VTKM_VERSION_MINOR > 2) || \
      (VTKM_VERSION_MAJOR == 2 && VTKM_VERSION_MINOR == 2 && VTKM_VERSION_PATCH > 0))
 
-#if VISTLE_INTERNAL_VTKM_ON
+#if VTKM_CONTAINS_CLANG_COMPILER_PATCH
 #include <vtkm/cont/PointLocatorBase.h>
 #else
 #include <vtkm/cont/internal/PointLocatorBase.h>
@@ -21,7 +21,7 @@
 #include "OverlapDetector.h"
 #include "../ThicknessDeterminer.h"
 
-#if VISTLE_INTERNAL_VTKM_ON
+#if VTKM_CONTAINS_CLANG_COMPILER_PATCH
 class PointLocatorCellLists: public vtkm::cont::PointLocatorBase {
     using Superclass = vtkm::cont::PointLocatorBase;
 #else

--- a/module/geometry/SpheresOverlap/algo/worklet/PointLocatorCellLists.h
+++ b/module/geometry/SpheresOverlap/algo/worklet/PointLocatorCellLists.h
@@ -5,15 +5,15 @@
 
 // Note that the version macros are only defined if find_package is called, which is
 // not the the case if Vistle builds VTK-m, i.e., VISTLE_INTERNAL_VTKM is defined.
-#define VTKM_CONTAINS_CLANG_COMPILER_PATCH \
-    ((defined(VISTLE_INTERNAL_VTKM_ON)) || (VTKM_VERSION_MAJOR > 2) || \
-     (VTKM_VERSION_MAJOR == 2 && VTKM_VERSION_MINOR > 2) || \
-     (VTKM_VERSION_MAJOR == 2 && VTKM_VERSION_MINOR == 2 && VTKM_VERSION_PATCH > 0))
+#if defined(VISTLE_EXTERNAL_VTKM) && (VTKM_VERSION_MAJOR < 2 || (VTKM_VERSION_MAJOR == 2 && VTKM_VERSION_MINOR < 2) || \
+                                      (VTKM_VERSION_MAJOR == 2 && VTKM_VERSION_MINOR == 2 && VTKM_VERSION_PATCH < 90))
+#define VTKM_INTERNAL_POINTLOCATORBASE
+#endif
 
-#if VTKM_CONTAINS_CLANG_COMPILER_PATCH
-#include <vtkm/cont/PointLocatorBase.h>
-#else
+#ifdef VTKM_INTERNAL_POINTLOCATORBASE
 #include <vtkm/cont/internal/PointLocatorBase.h>
+#else
+#include <vtkm/cont/PointLocatorBase.h>
 #endif
 
 #include <vistle/core/scalar.h>
@@ -21,12 +21,12 @@
 #include "OverlapDetector.h"
 #include "../ThicknessDeterminer.h"
 
-#if VTKM_CONTAINS_CLANG_COMPILER_PATCH
-class PointLocatorCellLists: public vtkm::cont::PointLocatorBase {
-    using Superclass = vtkm::cont::PointLocatorBase;
-#else
+#ifdef VTKM_INTERNAL_POINTLOCATORBASE
 class PointLocatorCellLists: public vtkm::cont::internal::PointLocatorBase<PointLocatorCellLists> {
     using Superclass = vtkm::cont::internal::PointLocatorBase<PointLocatorCellLists>;
+#else
+class PointLocatorCellLists: public vtkm::cont::PointLocatorBase {
+    using Superclass = vtkm::cont::PointLocatorBase;
 #endif
 
 public:


### PR DESCRIPTION
The current commit for the VTK-m submodule (updated in commit [ebd448d](https://github.com/vistle/vistle/commit/ebd448d16c05b865bf242c44e643f3574fe57a54)) contains a clang compile fix that is not available in the official release version yet.
In that commit PointLocatorBase.h has been moved from vtkm/cont/internal/ to vtkm/cont/ as well. To make sure SpheresOverlap can be used with both the release as well as the newer patched version, the VTKM_CONTAINS_CLANG_COMPILER_PATCH macro make sure the correct header is called.