### PR TITLE
when just cloning the type of an object, also copy its attributes

### DIFF
--- a/lib/vistle/control/hub.cpp
+++ b/lib/vistle/control/hub.cpp
@@ -4179,13 +4179,13 @@ bool Hub::checkChildProcesses(bool emergency, bool onMainThread)
             if (onMainThread) {
                 stopVrb();
             } else {
-                if (m_verbose >= Verbosity::Manager) {
-                    if (m_vrbPort == 0) {
-                        exitOk = true;
-                    } else {
+                if (m_vrbPort == 0) {
+                    exitOk = true;
+                } else {
+                    if (m_verbose >= Verbosity::Manager) {
                         CERR << "VRB on port " << m_vrbPort << " has exited" << std::endl;
-                        stopVrb();
                     }
+                    stopVrb();
                 }
             }
             assert(m_vrbPort == 0);

--- a/lib/vistle/core/object.cpp
+++ b/lib/vistle/core/object.cpp
@@ -585,20 +585,6 @@ void Object::copyAttributes(Object::const_ptr src, bool replace)
     if (!src)
         return;
 
-    if (replace) {
-        auto &m = d()->meta;
-        auto &sm = src->meta();
-        m.setBlock(sm.block());
-        m.setNumBlocks(sm.numBlocks());
-        m.setTimeStep(sm.timeStep());
-        m.setNumTimesteps(sm.numTimesteps());
-        m.setRealTime(sm.realTime());
-        m.setAnimationStep(sm.animationStep());
-        m.setNumAnimationSteps(sm.numAnimationSteps());
-        m.setIteration(sm.iteration());
-        m.setTransform(sm.transform());
-    }
-
     d()->copyAttributes(src->d(), replace);
 }
 
@@ -648,6 +634,18 @@ void Object::Data::copyAttributes(const ObjectData *src, bool replace)
 {
     if (replace) {
         attributes = src->attributes;
+
+        auto &m = meta;
+        auto &sm = src->meta;
+        m.setBlock(sm.block());
+        m.setNumBlocks(sm.numBlocks());
+        m.setTimeStep(sm.timeStep());
+        m.setNumTimesteps(sm.numTimesteps());
+        m.setRealTime(sm.realTime());
+        m.setAnimationStep(sm.animationStep());
+        m.setNumAnimationSteps(sm.numAnimationSteps());
+        m.setIteration(sm.iteration());
+        m.setTransform(sm.transform());
     } else {
         const AttributeMap &a = src->attributes;
 

--- a/lib/vistle/core/object.h
+++ b/lib/vistle/core/object.h
@@ -420,7 +420,9 @@ public: \
     } \
     Object::ptr cloneTypeInternal() const override \
     { \
-        return Object::ptr(new ObjType(Object::Initialized)); \
+        auto clone = std::make_shared<ObjType>(Object::Initialized); \
+        clone->d()->copyAttributes(this->d(), true); \
+        return clone; \
     } \
     static Object *createEmpty(const std::string &name) \
     { \

--- a/lib/vistle/core/parametermanager.cpp
+++ b/lib/vistle/core/parametermanager.cpp
@@ -7,6 +7,8 @@
 #include <iostream>
 #include <regex>
 
+#include "parametermanager_impl.h"
+
 #define CERR std::cerr << message::Id::name(m_name, m_id) << ": "
 
 namespace vistle {

--- a/lib/vistle/core/parametermanager.h
+++ b/lib/vistle/core/parametermanager.h
@@ -147,16 +147,21 @@ private:
         const std::string &name, const std::string &description, const Type &value, \
         Parameter::Presentation presentation); \
     spec template V_COREEXPORT bool ParameterManager::setParameter<Type>(const std::string &name, const Type &value, \
-                                                                         const message::SetParameter *inResponseTo);
+                                                                         const message::SetParameter *inResponseTo); \
+    spec template bool ParameterManager::setParameter<Type>(ParameterBase<Type> *, Type const &, \
+                                                            message::SetParameter const *); \
+    spec template bool ParameterManager::setParameterRange<Type>(const std::string &, Type const &, Type const &); \
+    spec template bool ParameterManager::setParameterRange<Type>(ParameterBase<Type> *, Type const &, Type const &); \
+    spec template bool ParameterManager::setParameterMinimum<Type>(ParameterBase<Type> *, Type const &); \
+    spec template bool ParameterManager::setParameterMaximum<Type>(ParameterBase<Type> *, Type const &);
 
 PARAM_TYPE_TEMPLATE(extern, Integer)
 PARAM_TYPE_TEMPLATE(extern, Float)
 PARAM_TYPE_TEMPLATE(extern, std::string)
 PARAM_TYPE_TEMPLATE(extern, ParameterVector<Integer>)
-PARAM_TYPE_TEMPLATE(extern, ParameterVector<Float>)
-PARAM_TYPE_TEMPLATE(extern, ParameterVector<std::string>)
+PARAM_TYPE_TEMPLATE(extern, ParameterVector<Float>) PARAM_TYPE_TEMPLATE(extern, ParameterVector<std::string>)
 
 } // namespace vistle
 
-#include "parametermanager_impl.h"
+//#include "parametermanager_impl.h"
 #endif

--- a/lib/vistle/core/parametermanager_impl.h
+++ b/lib/vistle/core/parametermanager_impl.h
@@ -28,12 +28,13 @@ bool ParameterManager::setParameter(ParameterBase<T> *param, const T &value, con
     bool delayed = false;
     if (inResponseTo && inResponseTo->isDelayed())
         delayed = true;
+    bool changed = value != param->getValue();
     param->setValue(value, false, delayed);
-    if (!inResponseTo || !inResponseTo->isDelayed())
+    if (!delayed)
         parameterChangedWrapper(param);
     else
         m_delayedChanges.emplace(param->getName(), param);
-    if (param->getValue() == value) {
+    if (!changed) {
         return true;
     }
     return updateParameter(param->getName(), param, inResponseTo);

--- a/module/filter/Threshold/Threshold.cpp
+++ b/module/filter/Threshold/Threshold.cpp
@@ -334,9 +334,7 @@ bool Threshold::compute(const std::shared_ptr<BlockTask> &task) const
         *el = cidx;
 
         renumberVertices(grid_in, outgrid, vm);
-        outgrid->setMeta(grid_in->meta());
         updateMeta(outgrid);
-        outgrid->copyAttributes(grid_in);
 
         cachedResult.grid = outgrid;
         m_gridCache.storeAndUnlock(cacheEntry, cachedResult);

--- a/module/geometry/FlattenTriangles/FlattenTriangles.cpp
+++ b/module/geometry/FlattenTriangles/FlattenTriangles.cpp
@@ -107,8 +107,6 @@ bool FlattenTriangles::compute()
             Triangles::ptr tri = intri->cloneType();
             tri->setSize(intri->getNumCorners());
             flatten(intri, intri, tri);
-            tri->setMeta(intri->meta());
-            tri->copyAttributes(intri);
             outgrid = tri;
         }
     } else if (inquad) {
@@ -119,8 +117,6 @@ bool FlattenTriangles::compute()
             Quads::ptr q = inquad->cloneType();
             q->setSize(inquad->getNumCorners());
             flatten(inquad, inquad, q);
-            q->setMeta(inquad->meta());
-            q->copyAttributes(inquad);
             outgrid = q;
         }
     }

--- a/module/geometry/SplitPolyhedra/SplitPolyhedra.cpp
+++ b/module/geometry/SplitPolyhedra/SplitPolyhedra.cpp
@@ -472,7 +472,6 @@ bool SplitPolyhedra::compute()
                 for (Index e = 0; e < elementMapping.size(); ++e) {
                     ndata->copyEntry(e, data[i], elementMapping[e]);
                 }
-                ndata->copyAttributes(data[i]);
             } else {
                 ndata = data[i]->clone();
             }

--- a/module/geometry/ToPoints/ToPoints.cpp
+++ b/module/geometry/ToPoints/ToPoints.cpp
@@ -101,7 +101,6 @@ bool ToPoints::compute()
                     const Index *cl = verts.data();
                     size_t nconn = verts.size();
                     auto odata = split.mapped->cloneType();
-                    odata->copyAttributes(split.mapped);
                     data = odata;
                     odata->setSize(nconn);
                     for (Index i = 0; i < nconn; ++i) {

--- a/module/map/IndexManifolds/IndexManifolds.cpp
+++ b/module/map/IndexManifolds/IndexManifolds.cpp
@@ -158,7 +158,6 @@ bool IndexManifolds::compute(const std::shared_ptr<BlockTask> &task) const
             task->addObject(p_surface_out, surface);
         } else {
             DataBase::ptr outdata = data->cloneType();
-            outdata->copyAttributes(data);
             outdata->setMapping(elementData ? DataBase::Element : DataBase::Vertex);
             outdata->setGrid(surface);
             outdata->setSize(elementData ? nquad : nvert);
@@ -210,7 +209,6 @@ bool IndexManifolds::compute(const std::shared_ptr<BlockTask> &task) const
             outdata = data->cloneType();
             outdata->setSize(elementData ? nvert - 1 : nvert);
             outdata->setGrid(line);
-            outdata->copyAttributes(data);
         }
 
         Index cell = 0;
@@ -262,7 +260,6 @@ bool IndexManifolds::compute(const std::shared_ptr<BlockTask> &task) const
             outdata = data->cloneType();
             outdata->setSize(1);
             outdata->setGrid(point);
-            outdata->copyAttributes(data);
         }
         for (int d = 0; d < 3; ++d)
             point->x(d)[0] = p[d];

--- a/module/test/FilterNode/FilterNode.cpp
+++ b/module/test/FilterNode/FilterNode.cpp
@@ -74,8 +74,6 @@ bool FilterNode::compute()
         addObject("data_out", ndata);
     } else {
         Object::ptr obj = data->cloneType();
-        obj->setMeta(data->meta());
-        obj->copyAttributes(data);
         updateMeta(obj);
         addObject("data_out", obj);
     }


### PR DESCRIPTION
as cloneType is used most often to create subsets of the input data