### PR TITLE
do not overwrite transform with (identity) transform from data

### DIFF
--- a/module/geometry/SpheresOverlap/SpheresOverlap.cpp
+++ b/module/geometry/SpheresOverlap/SpheresOverlap.cpp
@@ -103,10 +103,10 @@ bool SpheresOverlap::compute(const std::shared_ptr<BlockTask> &task) const
     }
 
     if (lines->getNumCoords()) {
+        lines->copyAttributes(geo);
         if (mappedData) {
             lines->copyAttributes(mappedData);
-        } else {
-            lines->copyAttributes(geo);
+            lines->setTransform(geo->getTransform());
         }
 
         updateMeta(lines);

--- a/module/map/VectorField/VectorField.cpp
+++ b/module/map/VectorField/VectorField.cpp
@@ -173,6 +173,7 @@ bool VectorField::compute()
     lines->setTimestep(split.timestep);
     lines->copyAttributes(coords);
     lines->copyAttributes(vecs);
+    lines->setTransform(coords->getTransform());
     updateMeta(lines);
 
     if (mapped) {
@@ -183,7 +184,6 @@ bool VectorField::compute()
             mapped->copyEntry(i * 2 + 1, data, ii);
         }
         mapped->setMeta(data->meta());
-        mapped->copyAttributes(coords);
         mapped->copyAttributes(data);
 
         mapped->setGrid(lines);


### PR DESCRIPTION
Sometimes, if only geometry is generated based on grid and data, it is useful
to copy attributes from both grid and data to the newly generated
geometry. Transformations, however, should always get reused from the
grid.