### PR TITLE
add required locking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,7 +721,7 @@ macro(vistle_add_library targetname visibility)
            AND NOT "${targetname}" STREQUAL "simV2runtime_ser")
             message(WARNING " missing prefix for " ${targetname}": vistle libraries must be prefixed with vistle_")
         endif()
-    elseif() # change the vistle_libname to vistle::libname in exported target
+    else() # change the vistle_libname to vistle::libname in exported target
         string(REPLACE "vistle_" "" target_suffix ${targetname})
         set_target_properties(${targetname} PROPERTIES EXPORT_NAME ${target_suffix})
         add_library(vistle::${target_suffix} ALIAS ${targetname})

--- a/lib/vistle/manager/clustermanager.h
+++ b/lib/vistle/manager/clustermanager.h
@@ -179,6 +179,7 @@ private:
         bool prepared = false, reduced = true;
         int busyCount = 0;
         // handling of outgoing messages
+        mutable std::mutex messageMutex; // mutex for message handling
         mutable bool blocked = false; // any message is blocking and cannot be sent right away
         mutable std::deque<message::Buffer> blockers; // queue of blocking messages
         mutable std::deque<MessageWithPayload> blockedMessages; // again, but with payload


### PR DESCRIPTION
Data objects are received on data manager threads, hence access to module's message queues has to be serialized with main thread message processing.