### PR TITLE
compatibility with Boost 1.89.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,6 @@ vistle_find_package(
     1.78
     REQUIRED
     COMPONENTS
-    system
     serialization
     program_options
     date_time
@@ -518,7 +517,11 @@ vistle_find_package(
     timer
     ${BOOST_REQ}
     OPTIONAL_COMPONENTS
+    system
     ${BOOST_OPT})
+if(NOT TARGET Boost::system)
+    add_library(Boost::system ALIAS Boost::boost)
+endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-command-line-argument")

--- a/lib/vistle/insitu/message/ShmMessage.cpp
+++ b/lib/vistle/insitu/message/ShmMessage.cpp
@@ -1,7 +1,10 @@
 #include "ShmMessage.h"
 #include <fstream>
 #include <vistle/insitu/core/exception.h>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 using namespace vistle::insitu::message;
+
 bool InSituShmMessage::sendMessage(InSituMessageType type, const vistle::buffer &vec) const
 { // not thread safe
 


### PR DESCRIPTION
as Boost::system no longer exists, add an alias target