### PR TITLE
Update Kokkos version of Viskores to use shallow copies on AMD APUs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,7 +62,7 @@
 	url = https://github.com/vistle/tetgen.git
 [submodule "lib/3rdparty/viskores"]
 	path = lib/3rdparty/viskores
-	url = https://github.com/Viskores/viskores.git
+	url = https://github.com/DeVasconcelos/viskores.git
 [submodule "lib/3rdparty/mpi-serial"]
 	path = lib/3rdparty/mpi-serial
 	url = https://github.com/vistle/mpi-serial.git


### PR DESCRIPTION
If `KOKKOS_ARCH_AMD_GFX942_APU` is defined (which is currently only the case on AMD MI300A), no copies between host and device will be made. Instead it is assumed that host and device can both access the same data.

For now, this is implemented in a Viskores fork.