### PR TITLE
do not update linked parameters before parameter has received its value

### DIFF
--- a/lib/vistle/control/hub.cpp
+++ b/lib/vistle/control/hub.cpp
@@ -4163,8 +4163,10 @@ void Hub::handleMirrorConnect(const ConnMsg &conn, std::function<bool(const mess
         return;
     if (portA->getType() == Port::PARAMETER || portB->getType() == Port::PARAMETER) {
         if (const auto param = state.getParameter(modA, portA->getName())) {
-            message::SetParameter setParam(modA, portA->getName(), param);
-            updateLinkedParameters(setParam);
+            if (param->hasValue()) {
+                message::SetParameter setParam(modA, portA->getName(), param);
+                updateLinkedParameters(setParam);
+            }
         }
         return;
     }

--- a/lib/vistle/core/parameter.cpp
+++ b/lib/vistle/core/parameter.cpp
@@ -20,7 +20,8 @@ Parameter::Parameter(int moduleId, const std::string &n, Parameter::Type type, P
 {}
 
 Parameter::Parameter(const Parameter &other)
-: m_choices(other.m_choices)
+: m_hasValue(other.m_hasValue)
+, m_choices(other.m_choices)
 , m_module(other.m_module)
 , m_name(other.m_name)
 , m_description(other.m_description)
@@ -30,6 +31,11 @@ Parameter::Parameter(const Parameter &other)
 
 Parameter::~Parameter()
 {}
+
+bool Parameter::hasValue() const
+{
+    return m_hasValue;
+}
 
 void Parameter::setDescription(const std::string &d)
 {

--- a/lib/vistle/core/parameter.h
+++ b/lib/vistle/core/parameter.h
@@ -78,6 +78,7 @@ public:
 
     virtual operator std::string() const = 0;
     virtual bool isDefault() const = 0;
+    bool hasValue() const;
     virtual bool checkChoice(const std::vector<std::string> &choices) const { return true; }
     int module() const;
     const std::string &getName() const;
@@ -89,6 +90,7 @@ public:
     bool isImmediate() const;
 
 protected:
+    bool m_hasValue = false;
     std::vector<std::string> m_choices;
 
 private:
@@ -141,6 +143,7 @@ class ParameterBase: public Parameter {
 
     virtual bool setValue(T value, bool init = false, bool delayed = false)
     {
+        m_hasValue = true;
         if (init)
             m_defaultValue = value;
         else if (!delayed && !checkValue(value))
@@ -154,13 +157,22 @@ class ParameterBase: public Parameter {
 public:
     typedef T ValueType;
 
-    ParameterBase(int moduleId, const std::string &name, T value = T())
+    ParameterBase(int moduleId, const std::string &name)
+    : Parameter(moduleId, name, ParameterType<T>::type)
+    , m_value(T())
+    , m_defaultValue(T())
+    , m_minimum(ParameterType<T>::min())
+    , m_maximum(ParameterType<T>::max())
+    {}
+    ParameterBase(int moduleId, const std::string &name, T value)
     : Parameter(moduleId, name, ParameterType<T>::type)
     , m_value(value)
     , m_defaultValue(value)
     , m_minimum(ParameterType<T>::min())
     , m_maximum(ParameterType<T>::max())
-    {}
+    {
+        m_hasValue = true;
+    }
     ParameterBase(const ParameterBase<T> &other)
     : Parameter(other)
     , m_value(other.m_value)


### PR DESCRIPTION
Otherwise, the linked parameter would be set to zero.