### PR TITLE
Update Viskores submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,7 +62,7 @@
 	url = https://github.com/vistle/tetgen.git
 [submodule "lib/3rdparty/viskores"]
 	path = lib/3rdparty/viskores
-	url = https://github.com/DeVasconcelos/viskores.git
+	url = https://github.com/Viskores/viskores.git
 [submodule "lib/3rdparty/mpi-serial"]
 	path = lib/3rdparty/mpi-serial
 	url = https://github.com/vistle/mpi-serial.git


### PR DESCRIPTION
The changes in the Kokkos device adapter, which now takes into account AMD APUs by avoiding data copies between host and device, have been merged into the main Viskores repository, so we can go back to it now.