### PR TITLE
use libraries as discovered by FindCOVER.cmake

### DIFF
--- a/lib/vistle/util/findself.cpp
+++ b/lib/vistle/util/findself.cpp
@@ -68,11 +68,17 @@ std::string getbindir(int argc, char *argv[])
         std::cerr << "Communicator: getbindir(): GetModuleFileName failed - error: " << GetLastError() << std::endl;
     }
 #else
-    char buf[PATH_MAX];
+    char buf[PATH_MAX + 1];
 #ifdef __APPLE__
     uint32_t size = sizeof(buf);
-    if (_NSGetExecutablePath(buf, &size) == 0) {
-        executable = buf;
+    auto result = _NSGetExecutablePath(buf, &size);
+    char *exec = nullptr;
+    if (result == 0)
+        exec = realpath(buf, nullptr);
+    if (result == 0 && exec != nullptr) {
+        executable = exec;
+        free(exec);
+        exec = nullptr;
     } else
 #else
     ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf));

--- a/lib/vistle/vtk/vtktovistle.cpp
+++ b/lib/vistle/vtk/vtktovistle.cpp
@@ -19,6 +19,7 @@
 
 #include <vtkAlgorithm.h>
 #include <vtkCellArray.h>
+#include <vtkIdList.h>
 #include <vtkCellData.h>
 #include <vtkCompositeDataSet.h>
 #include <vtkImageData.h>
@@ -330,43 +331,44 @@ Object::ptr vtkUGrid2Vistle(vtkUnstructuredGrid *vugrid, std::string &diagnostic
 
         assert(typelist[elemVistle] < UnstructuredGrid::NUM_TYPES);
 
-        vtkIdType npts = 0;
-        IDCONST vtkIdType *pts = nullptr;
-        vugrid->GetFaceStream(i, npts, pts);
         if (typelist[elemVistle] == UnstructuredGrid::POLYHEDRON) {
-            Index nface = npts;
-
-            vtkIdType j = 0;
+            vtkNew<vtkIdList> faceStream;
+            vugrid->GetFaceStream(i, faceStream);
+            Index nface = faceStream->GetId(0);
+            vtkIdType j = 1;
             for (Index f = 0; f < nface; ++f) {
-                assert(pts[j] >= 0);
-                Index nvert = pts[j];
+                Index nvert = faceStream->GetId(j);
                 ++j;
-                Index first = pts[j];
+                Index first = faceStream->GetId(j);
                 for (Index v = 0; v < nvert; ++v) {
-                    assert(pts[j] >= 0);
-                    connlist.emplace_back(pts[j]);
+                    connlist.emplace_back(faceStream->GetId(j));
                     ++j;
                 }
                 connlist.emplace_back(first);
             }
-        } else if (vugrid->GetCellType(i) == VTK_LAGRANGE_HEXAHEDRON) {
-            auto lagrangeCell = static_cast<vtkLagrangeHexahedron *>(vugrid->GetCell(i));
-            lagrangeConnectivityToLinearHexahedron(lagrangeCell->GetOrder(), pts, connlist);
-        } else if (vugrid->GetCellType(i) == VTK_LAGRANGE_QUADRILATERAL) {
-            auto lagrangeCell = static_cast<vtkLagrangeQuadrilateral *>(vugrid->GetCell(i));
-            lagrangeConnectivityToLinearQuadrilateral(lagrangeCell->GetOrder(), pts, connlist);
-        } else if (vugrid->GetCellType(i) == VTK_PIXEL || vugrid->GetCellType(i) == VTK_VOXEL) {
-            // account for different order
-            constexpr Index vtkOrder[] = {0, 1, 3, 2, 4, 5, 7, 6};
-            assert(npts <= sizeof(vtkOrder) / sizeof(vtkOrder[0]));
-            for (vtkIdType j = 0; j < npts; ++j) {
-                assert(pts[j] >= 0);
-                connlist.emplace_back(pts[vtkOrder[j]]);
-            }
         } else {
-            for (vtkIdType j = 0; j < npts; ++j) {
-                assert(pts[j] >= 0);
-                connlist.emplace_back(pts[j]);
+            vtkIdType npts = 0;
+            vtkIdType const *pts = nullptr;
+            vugrid->GetCellPoints(i, npts, pts);
+            if (vugrid->GetCellType(i) == VTK_LAGRANGE_HEXAHEDRON) {
+                auto lagrangeCell = static_cast<vtkLagrangeHexahedron *>(vugrid->GetCell(i));
+                lagrangeConnectivityToLinearHexahedron(lagrangeCell->GetOrder(), pts, connlist);
+            } else if (vugrid->GetCellType(i) == VTK_LAGRANGE_QUADRILATERAL) {
+                auto lagrangeCell = static_cast<vtkLagrangeQuadrilateral *>(vugrid->GetCell(i));
+                lagrangeConnectivityToLinearQuadrilateral(lagrangeCell->GetOrder(), pts, connlist);
+            } else if (vugrid->GetCellType(i) == VTK_PIXEL || vugrid->GetCellType(i) == VTK_VOXEL) {
+                // account for different vertex order
+                constexpr Index vtkOrder[] = {0, 1, 3, 2, 4, 5, 7, 6};
+                assert(npts <= sizeof(vtkOrder) / sizeof(vtkOrder[0]));
+                for (vtkIdType j = 0; j < npts; ++j) {
+                    assert(pts[j] >= 0);
+                    connlist.emplace_back(pts[vtkOrder[j]]);
+                }
+            } else {
+                for (vtkIdType j = 0; j < npts; ++j) {
+                    assert(pts[j] >= 0);
+                    connlist.emplace_back(pts[j]);
+                }
             }
         }
         ++elemVistle;

--- a/module/render/COVER/plugin/VisObjectSensor/CMakeLists.txt
+++ b/module/render/COVER/plugin/VisObjectSensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT COVER_VRML_LIBRARY)
+if(NOT COVER_VRML_LIBRARY OR NOT COVER_VRMLINTERFACE_LIBRARY)
     return()
 endif()
 
@@ -15,12 +15,10 @@ foreach(
     covise_find_package(${P})
 endforeach()
 
-using(VRML)
-
 set(HEADERS VisObjectSensor.h)
 set(SOURCES VisObjectSensor.cpp)
 
 cover_add_plugin(VisObjectSensor ${HEADERS} ${SOURCES})
 
 target_include_directories(VisObjectSensor PRIVATE ..) # for VistlePluginUtil
-target_link_libraries(VisObjectSensor Vrml97Cover VistlePluginUtil vistle_util vistle_core)
+target_link_libraries(VisObjectSensor ${COVER_VRMLINTERFACE_LIBRARY} ${COVER_VRML_LIBRARY} VistlePluginUtil vistle_util vistle_core)


### PR DESCRIPTION
instead of `USING(VRLM)`, which links against hard-coded libraries