### PR TITLE
generally enable --allow-run-as-root

### DIFF
--- a/bin/spawn_vistle.sh
+++ b/bin/spawn_vistle.sh
@@ -201,8 +201,11 @@ fi
 
 case "$MPI_IMPL" in
     ompi)
-        if [ -n "$CONTAINER" ]; then
+        if [ "$(id)" = "0" ]; then
             ALLOWROOT="--allow-run-as-root"
+            if [ -z "$CONTAINER" ]; then
+                echo "Running as root, even though not in container"
+            fi
         fi
         case "$BINDTO" in
             none|numa)

--- a/bin/spawn_vistle.sh
+++ b/bin/spawn_vistle.sh
@@ -44,8 +44,8 @@ function doexec() {
     exec "$@" < /dev/null
 }
 
-CONTAINER=
-if [ -f /.dockerenv ]; then
+CONTAINER=${container}
+if [ -z "$CONTAINER" -a -f /.dockerenv ]; then
     CONTAINER=docker
 fi
 


### PR DESCRIPTION
it's hard to detect reliably that we are running in a containerized
environment