### PR TITLE
restore compatibility with Boost 1.75

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,11 +531,11 @@ if(APPLE)
     add_definitions(-DBOOST_INTERPROCESS_POSIX_PROCESS_SHARED)
 endif()
 
-vistle_find_package(Boost 1.78 OPTIONAL_COMPONENTS system QUIET)
+vistle_find_package(Boost 1.75 OPTIONAL_COMPONENTS system QUIET)
 
 vistle_find_package(
     Boost
-    1.78
+    1.75
     REQUIRED
     COMPONENTS
     serialization

--- a/lib/vistle/core/archives_impl.h
+++ b/lib/vistle/core/archives_impl.h
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
-#include <boost/core/span.hpp>
+#include <span>
 
 #include <vistle/util/enum.h>
 #include <vistle/util/buffer.h>
@@ -377,7 +377,7 @@ void archive_helper<yas_tag>::ArrayWrapper<T>::save(Archive &ar) const
         assert(!compBigWhoop);
         size_t outSize = 0;
         if (char *compressedData = compressSz3<typename lossy_type_map<T>::sz3type>(outSize, m_begin, m_dim, cs)) {
-            boost::span compressed(compressedData, outSize);
+            std::span compressed(compressedData, outSize);
             ar &compressMode;
             ar &m_dim[0] & m_dim[1] & m_dim[2];
             ar &compressed;

--- a/lib/vistle/core/yas_span.h
+++ b/lib/vistle/core/yas_span.h
@@ -7,21 +7,21 @@
 
 #include <yas/types/concepts/array.hpp>
 
-#include <boost/core/span.hpp>
+#include <span>
 
 namespace yas {
 namespace detail {
 
 template<std::size_t F, typename T, std::size_t E>
-struct serializer<type_prop::not_a_fundamental, ser_case::use_internal_serializer, F, boost::span<T, E>> {
+struct serializer<type_prop::not_a_fundamental, ser_case::use_internal_serializer, F, std::span<T, E>> {
     template<typename Archive>
-    static Archive &save(Archive &ar, const boost::span<T, E> &span)
+    static Archive &save(Archive &ar, const std::span<T, E> &span)
     {
         return concepts::array::save<F>(ar, span);
     }
 
     template<typename Archive>
-    static Archive &load(Archive &ar, boost::span<T, E> &span)
+    static Archive &load(Archive &ar, std::span<T, E> &span)
     {
         return concepts::array::load<F>(ar, span);
     }


### PR DESCRIPTION
C++ 20 provides std::span, so no need to depend on Boost 1.78 for boost::span