### PR TITLE
use known normal mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ Installation
 #### Build Requirements
 
 - **C++ compiler**:
-  support for C++14 (ISO/IEC 14882:2014) is required,
+  support for C++20 (ISO/IEC 14882:2020) is required,
   known good compilers:
-    - GCC (8-14)
-    - Clang (Xcode 14, 15)
-    - Microsoft Visual Studio 2022
+    - GCC (11-16)
+    - Apple Clang (Xcode 14, 15, 26)
+    - Microsoft Visual Studio (2022, 2025)
 
 - **CMake**:
   at least 3.10, on Windows 3.15
 
 - **Boost**:
-  At least 1.66.00 is required.
+  At least 1.75.00 is required.
      Note:
      - in order to switch MPI implementations without requiring a recompilation of Boost, we compile Boost.MPI together with Vistle
 

--- a/lib/vistle/core/parameter.h
+++ b/lib/vistle/core/parameter.h
@@ -291,7 +291,8 @@ struct ParameterCheck<Integer> {
             return true;
         }
         if (value < 0 || size_t(value) >= choices.size()) {
-            std::cerr << "IntParameter: choice out of range" << std::endl;
+            std::cerr << "IntParameter: choice " << value << " out of range - have " << choices.size() << " choices"
+                      << std::endl;
             return false;
         }
         return true;

--- a/lib/vistle/module/module.cpp
+++ b/lib/vistle/module/module.cpp
@@ -185,13 +185,16 @@ double getRealTime(Object::const_ptr obj)
     return ret;
 }
 
-bool Module::setup(const std::string &shmname, const std::string &classname, const std::string &modulename,
-                   int moduleID, const std::string &cluster, int rank)
+bool Module::setup(const std::string &shmname, const std::string &classname, std::string modulename, int moduleID,
+                   const std::string &cluster, int rank)
 {
     const char *env = getenv("VISTLE_STARTUP_DELAY");
     if (env && env[0]) {
         const std::string delay = env;
         int delaySec = atoi(delay.c_str());
+        auto fn = modulename.find_last_of("/");
+        if (fn != std::string::npos)
+            modulename = modulename.substr(fn + 1);
         if (delaySec > 0 || delay == classname || delay == modulename) {
             if (delaySec <= 0)
                 delaySec = 20;

--- a/lib/vistle/module/module.h
+++ b/lib/vistle/module/module.h
@@ -123,8 +123,8 @@ class V_MODULEEXPORT Module: public ParameterManager, public MessageSender {
     friend class BlockTask;
 
 public:
-    static bool setup(const std::string &shmname, const std::string &classname, const std::string &modulename,
-                      int moduleID, const std::string &cluster, int rank);
+    static bool setup(const std::string &shmname, const std::string &classname, std::string modulename, int moduleID,
+                      const std::string &cluster, int rank);
     static bool cleanup(bool dedicated_process);
 
     Module(const std::string &name, const int moduleID, mpi::communicator comm);

--- a/lib/vistle/util/fileio.cpp
+++ b/lib/vistle/util/fileio.cpp
@@ -1,4 +1,5 @@
 #include "fileio.h"
+#include <cassert>
 
 namespace vistle {
 namespace file {
@@ -6,6 +7,7 @@ namespace file {
 
 ssize_t tell(const int fd)
 {
+    assert(fd >= 0);
 #ifdef WIN32
     return _lseeki64(fd, 0, SEEK_CUR);
 #else
@@ -24,6 +26,7 @@ ssize_t tell(FILE *file)
 
 ssize_t seek(int fd, ssize_t off, int whence)
 {
+    assert(fd >= 0);
 #ifdef WIN32
     return _lseeki64(fd, off, whence);
 #else

--- a/module/read/ReadCovise/ReadCovise.cpp
+++ b/module/read/ReadCovise/ReadCovise.cpp
@@ -866,7 +866,7 @@ bool ReadCovise::readGEOTEX(Token &token, const int port, int fd, Element *elem)
     bool ok = true;
     for (size_t i = 0; i < ncomp; ++i) {
         Element *e = new Element();
-        e->offset = file::tell(fd);
+        e->offset = file::tell(abs(fd));
         if (contains[i])
             ok &= readSkeleton(port, e);
         elem->subelems.push_back(e);
@@ -888,7 +888,7 @@ bool ReadCovise::readGEOMET(Token &token, const int port, int fd, Element *elem)
     bool ok = true;
     for (size_t i = 0; i < ncomp; ++i) {
         Element *e = new Element();
-        e->offset = file::tell(fd);
+        e->offset = file::tell(abs(fd));
         if (contains[i])
             ok &= readSkeleton(port, e);
         elem->subelems.push_back(e);
@@ -947,9 +947,9 @@ Object::ptr ReadCovise::readObjectIntern(Token &token, const int port, int fd, c
     }
 
     if (skeleton) {
-        elem->offset = file::tell(fd);
+        elem->offset = file::tell(abs(fd));
     } else {
-        file::seek(fd, elem->offset);
+        file::seek(abs(fd), elem->offset);
     }
 
     char buf[7];
@@ -959,7 +959,7 @@ Object::ptr ReadCovise::readObjectIntern(Token &token, const int port, int fd, c
     }
     buf[6] = '\0';
     std::string type(buf);
-    //std::cerr << "ReadCovise::readObject " << type << " @ " << file::tell(fd) << std::endl;
+    //std::cerr << "ReadCovise::readObject " << type << " @ " << file::tell(abs(fd)) << std::endl;
 
     if (skeleton)
         elem->type = type;

--- a/module/read/ReadFoam/ReadFOAM.cpp
+++ b/module/read/ReadFoam/ReadFOAM.cpp
@@ -171,7 +171,7 @@ int ReadFOAM::rankForBlock(int processor) const
 
 bool ReadFOAM::examine(const Parameter *p)
 {
-    if (!p || p == m_casedir || p == m_foamRunDir) {
+    if (!p || p == m_casedir) {
         const std::string casedir = m_casedir->getValue();
         setFoamRunDir(m_casedir->isDefault() ? casedir : vistle::filesystem::path(casedir).parent_path().string());
 

--- a/module/read/ReadFoam/ReadFOAM.cpp
+++ b/module/read/ReadFoam/ReadFOAM.cpp
@@ -184,7 +184,9 @@ bool ReadFOAM::examine(const Parameter *p)
 
         m_case = getCaseInfo(casedir);
         if (!m_case.valid) {
-            std::cerr << casedir << " is not a valid OpenFOAM case" << std::endl;
+            std::stringstream str;
+            str << casedir << " is not a valid OpenFOAM case";
+            sendError(str.str());
             return false;
         }
         if (rank() == 0) {
@@ -208,8 +210,8 @@ bool ReadFOAM::examine(const Parameter *p)
                     sendInfo("%s", info.str().c_str());
                 }
             } else {
-                sendInfo("No global boundary file was found at %s",
-                         (m_case.casedir + "/constant/polyMesh/boundary").c_str());
+                sendWarning("No global boundary file was found at %s",
+                            (m_case.casedir + "/constant/polyMesh/boundary").c_str());
             }
         }
 
@@ -261,7 +263,9 @@ bool ReadFOAM::prepareRead()
     if (!m_case.valid)
         m_case = getCaseInfo(casedir);
     if (!m_case.valid) {
-        std::cerr << casedir << " is not a valid OpenFOAM case" << std::endl;
+        std::stringstream str;
+        str << casedir << " is not a valid OpenFOAM case";
+        sendError(str.str());
         return false;
     }
 

--- a/module/read/ReadFoam/ReadFOAM.cpp
+++ b/module/read/ReadFoam/ReadFOAM.cpp
@@ -57,7 +57,7 @@ ReadFOAM::ReadFOAM(const std::string &name, int moduleId, mpi::communicator comm
     // file browser parameter
     m_casedir =
         addStringParameter("casedir", "OpenFOAM case directory", "/data/OpenFOAM", Parameter::ExistingDirectory);
-    m_foamRunDir = addIntParameter("foam_case", "select a case to set it's directory as casedir", 0, Parameter::Choice);
+    m_foamRunDir = addIntParameter("foam_case", "select a case to set its directory as casedir", 0, Parameter::Choice);
     auto foamRunDir = getenv("FOAM_RUN");
 
     if (foamRunDir)

--- a/module/read/ReadFoam/ReadFOAM.cpp
+++ b/module/read/ReadFoam/ReadFOAM.cpp
@@ -128,16 +128,20 @@ void ReadFOAM::setFoamRunDir(const std::string &dir)
     m_foamRunBase = dir;
     m_foamCaseChoices.clear();
     m_foamCaseChoices.push_back("(Select case)");
-    for (auto &p: vistle::filesystem::directory_iterator(dir)) {
-        try {
-            if (vistle::filesystem::is_directory(p)) {
-                m_foamCaseChoices.push_back(p.path().filename().string());
+    try {
+        for (auto &p: vistle::filesystem::directory_iterator(dir)) {
+            try {
+                if (vistle::filesystem::is_directory(p)) {
+                    m_foamCaseChoices.push_back(p.path().filename().string());
+                }
+            } catch (const vistle::filesystem::filesystem_error &e) {
+                if (e.code() == std::errc::permission_denied)
+                    continue;
+                std::cerr << e.what() << '\n';
             }
-        } catch (const vistle::filesystem::filesystem_error &e) {
-            if (e.code() == std::errc::permission_denied)
-                continue;
-            std::cerr << e.what() << '\n';
         }
+    } catch (const vistle::filesystem::filesystem_error &e) {
+        std::cerr << e.what() << '\n';
     }
     setParameterChoices(m_foamRunDir, m_foamCaseChoices);
 }

--- a/module/read/ReadFoam/foamtoolbox.cpp
+++ b/module/read/ReadFoam/foamtoolbox.cpp
@@ -465,6 +465,11 @@ bool checkCaseSubDirectory(CaseInfo &info, const Path &dir, bool compare, bool e
         }
     }
 
+    if (info.constantdir.empty()) {
+        std::cerr << "did not find constant directory in " << dir.string() << std::endl;
+        return false;
+    }
+
     bool varyingChecked = false, constantChecked = false;
     for (Iterator it(dir); it != Iterator(); ++it)
     {

--- a/module/render/COVER/VistleGeometryGenerator.cpp
+++ b/module/render/COVER/VistleGeometryGenerator.cpp
@@ -375,6 +375,12 @@ void VistleGeometryGenerator::unlock()
     s_coverMutex.unlock();
 }
 
+// in order to not rely on guessing the normal mapping from the array size, store known mapping
+struct NormalsWithMapping {
+    osg::ref_ptr<osg::Vec3Array> array;
+    vistle::DataBase::Mapping mapping = vistle::DataBase::Unspecified;
+};
+
 template<class Geometry, class Array, class Mapped, bool normalize>
 struct DataAdapter;
 
@@ -437,22 +443,20 @@ struct DataAdapter<Geometry, osg::FloatArray, Mapped, normalize> {
 };
 
 template<class Geometry, bool normalize>
-struct DataAdapter<Geometry, osg::Vec3Array, osg::Vec3Array, normalize> {
-    DataAdapter(typename Geometry::const_ptr tri, osg::Vec3Array *mapped)
-    : size(mapped->size())
-    , mapping(size == tri->getNumElements() ? vistle::DataBase::Element : vistle::DataBase::Vertex)
-    , mapped(size > 0 ? mapped : nullptr)
+struct DataAdapter<Geometry, osg::Vec3Array, NormalsWithMapping, normalize> {
+    DataAdapter(typename Geometry::const_ptr /*tri*/, NormalsWithMapping *normals)
+    : size(normals->array ? normals->array->size() : 0), mapping(normals->mapping), normals(normals->array.get())
     {}
     osg::Vec3 getValue(Index idx)
     {
-        osg::Vec3 val = (*mapped)[idx];
+        osg::Vec3 val = (*normals)[idx];
         if (normalize)
             val.normalize();
         return val;
     }
     vistle::Index size = 0;
-    vistle::DataBase::Mapping mapping = vistle::DataBase::Vertex;
-    osg::Vec3Array *mapped = nullptr;
+    vistle::DataBase::Mapping mapping = vistle::DataBase::Unspecified;
+    osg::Vec3Array *normals = nullptr;
 };
 
 template<class Geometry, class MappedPtr, class Array, bool normalize>
@@ -558,7 +562,7 @@ Array *applyTriangle(typename Geometry::const_ptr tri, MappedPtr mapped, const O
 }
 
 template<class Geometry>
-osg::Vec3Array *computeNormals(typename Geometry::const_ptr geometry, const Options &options)
+NormalsWithMapping computeNormals(typename Geometry::const_ptr geometry, const Options &options)
 {
     PrimitiveAdapter<Geometry> geo(geometry);
 
@@ -571,9 +575,12 @@ osg::Vec3Array *computeNormals(typename Geometry::const_ptr geometry, const Opti
     const vistle::Scalar *y = geometry->y().data();
     const vistle::Scalar *z = geometry->z().data();
 
-    osg::Vec3Array *normals = new osg::Vec3Array;
+    NormalsWithMapping result;
+    result.array = new osg::Vec3Array;
+    osg::Vec3Array *normals = result.array.get();
     if (numCorners > 0) {
         bool useVertexNormals = options.indexedGeometry;
+        result.mapping = useVertexNormals ? vistle::DataBase::Vertex : vistle::DataBase::Element;
         normals->resize(useVertexNormals ? numCoords : numPrim);
         for (Index prim = 0; prim < numPrim; ++prim) {
             const Index begin = geo.getPrimitiveBegin(prim), end = geo.getPrimitiveBegin(prim + 1);
@@ -599,6 +606,7 @@ osg::Vec3Array *computeNormals(typename Geometry::const_ptr geometry, const Opti
                 (*normals)[v].normalize();
         }
     } else {
+        result.mapping = vistle::DataBase::Vertex;
         for (Index prim = 0; prim < numPrim; ++prim) {
             const Index begin = geo.getPrimitiveBegin(prim), end = geo.getPrimitiveBegin(prim + 1);
             const Index c = begin;
@@ -613,7 +621,7 @@ osg::Vec3Array *computeNormals(typename Geometry::const_ptr geometry, const Opti
         }
     }
 
-    return normals;
+    return result;
 }
 
 osg::PrimitiveSet *buildTrianglesFromTriangles(const PrimitiveBin &bin, const Options &options, const Byte *ghost)
@@ -1255,7 +1263,7 @@ std::vector<osg::ref_ptr<osg::Drawable>> VistleGeometryGenerator::handleTriangle
     info.debug << "Triangles: [ #c " << numCorners << ", #v " << numVertices
                << ", indexed=" << (m_options.indexedGeometry ? "t" : "f") << " ]";
 
-    osg::ref_ptr<osg::Vec3Array> gnormals;
+    NormalsWithMapping gnormals;
     if (!info.cached && !info.normals)
         gnormals = computeNormals<vistle::Triangles>(triangles, m_options);
 
@@ -1282,8 +1290,8 @@ std::vector<osg::ref_ptr<osg::Drawable>> VistleGeometryGenerator::handleTriangle
             osg::ref_ptr<osg::Vec3Array> norm = applyTriangle<Triangles, Normals::const_ptr, osg::Vec3Array, true>(
                 triangles, info.normals, m_options, bin);
             if (!norm)
-                norm = applyTriangle<Triangles, osg::Vec3Array *, osg::Vec3Array, false>(triangles, gnormals.get(),
-                                                                                         m_options, bin);
+                norm = applyTriangle<Triangles, NormalsWithMapping *, osg::Vec3Array, false>(
+                    triangles, gnormals.array ? &gnormals : nullptr, m_options, bin);
             geom->setNormalArray(norm.get());
             storeInCache(cache, vertices, ps, norm);
         }
@@ -1323,7 +1331,7 @@ std::vector<osg::ref_ptr<osg::Drawable>> VistleGeometryGenerator::handleQuads(No
     info.debug << "Quads: [ #c " << numCorners << ", #v " << numVertices
                << ", indexed=" << (m_options.indexedGeometry ? "t" : "f") << " ]";
 
-    osg::ref_ptr<osg::Vec3Array> gnormals;
+    NormalsWithMapping gnormals;
     if (!info.cached && !info.normals)
         gnormals = computeNormals<vistle::Quads>(quads, m_options);
 
@@ -1348,8 +1356,8 @@ std::vector<osg::ref_ptr<osg::Drawable>> VistleGeometryGenerator::handleQuads(No
             osg::ref_ptr<osg::Vec3Array> norm =
                 applyTriangle<Quads, Normals::const_ptr, osg::Vec3Array, true>(quads, info.normals, m_options, bin);
             if (!norm)
-                norm = applyTriangle<Quads, osg::Vec3Array *, osg::Vec3Array, false>(quads, gnormals.get(), m_options,
-                                                                                     bin);
+                norm = applyTriangle<Quads, NormalsWithMapping *, osg::Vec3Array, false>(
+                    quads, gnormals.array ? &gnormals : nullptr, m_options, bin);
             geom->setNormalArray(norm.get());
             storeInCache(info.cache, vertices, ps, norm);
         }
@@ -1393,7 +1401,7 @@ std::vector<osg::ref_ptr<osg::Drawable>> VistleGeometryGenerator::handlePolygons
 
     const Index *el = polygons->el().data();
 
-    osg::ref_ptr<osg::Vec3Array> gnormals;
+    NormalsWithMapping gnormals;
     if (!info.cached && !info.normals)
         gnormals = computeNormals<vistle::Indexed>(polygons, m_options);
 
@@ -1419,8 +1427,8 @@ std::vector<osg::ref_ptr<osg::Drawable>> VistleGeometryGenerator::handlePolygons
             osg::ref_ptr<osg::Vec3Array> norm = applyTriangle<Indexed, Normals::const_ptr, osg::Vec3Array, true>(
                 polygons, info.normals, m_options, bin);
             if (!norm)
-                norm = applyTriangle<Indexed, osg::Vec3Array *, osg::Vec3Array, false>(polygons, gnormals.get(),
-                                                                                       m_options, bin);
+                norm = applyTriangle<Indexed, NormalsWithMapping *, osg::Vec3Array, false>(
+                    polygons, gnormals.array ? &gnormals : nullptr, m_options, bin);
             geom->setNormalArray(norm.get());
             storeInCache(info.cache, vertices, ps, norm);
         }


### PR DESCRIPTION
When normals are computed in renderer, use knowledge of mapping.
This avoids relying on wrongly guessed normal mapping, if the number of vertices equals the
number of elements.