### PR TITLE
make sure that also renderers get their initial parameter values applied

### DIFF
--- a/lib/vistle/renderer/renderer.cpp
+++ b/lib/vistle/renderer/renderer.cpp
@@ -272,6 +272,8 @@ bool Renderer::dispatch(bool block, bool *messageReceived, unsigned int minPrio)
         ++numSync;
     } while (maxNumMessages > 0 && numSync < m_numObjectsPerFrame);
 
+    ParameterManager::applyDelayedChanges(); // normally done in Execute, but Renderer does not get executed
+
     double start = 0.;
     if (m_benchmark) {
         comm().barrier();


### PR DESCRIPTION
A renderer does not receive Execute messages, thus it is not sufficient
to call changeParameter for all parameters before handling this, hence
apply parameter changes before every frame.