### PR TITLE
Bug fix: AnariColorMap destructor must be called before the devices are released

### DIFF
--- a/module/render/ANARemote/anaremote.cpp
+++ b/module/render/ANARemote/anaremote.cpp
@@ -316,6 +316,8 @@ void Anari::unloadAnari()
 {
     releaseDevice(m_device);
 
+    m_colormaps.clear();
+
     if (m_wrapperDevice) {
         anari::unsetParameter(m_wrapperDevice, m_wrapperDevice, "wrappedDevice");
         anari::commitParameters(m_wrapperDevice, m_wrapperDevice);
@@ -326,6 +328,7 @@ void Anari::unloadAnari()
         anari::release(m_nestedDevice, m_nestedDevice);
         m_nestedDevice = nullptr;
     }
+
     m_device = nullptr;
 }
 


### PR DESCRIPTION
Otherwise Vistle crashes when quitting.