### PR TITLE
Make the colormap behavior in the viskores ANARI device match helide

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,7 +62,7 @@
 	url = https://github.com/vistle/tetgen.git
 [submodule "lib/3rdparty/viskores"]
 	path = lib/3rdparty/viskores
-	url = https://github.com/Viskores/viskores.git
+	url = https://github.com/DeVasconcelos/viskores.git
 [submodule "lib/3rdparty/mpi-serial"]
 	path = lib/3rdparty/mpi-serial
 	url = https://github.com/vistle/mpi-serial.git

--- a/module/render/ANARemote/anarirenderobject.cpp
+++ b/module/render/ANARemote/anarirenderobject.cpp
@@ -366,10 +366,12 @@ void AnariRenderObject::create(anari::Device device)
     if (haveColor) {
         anari::setParameter(device, mat, "color", "color");
     } else if (useSampler) {
-        if (colorMap)
+        if (colorMap) {
             anari::setParameter(device, mat, "color", colorMap->sampler);
-        else
+            anari::setParameter(device, geom, "useValueRange", true);
+        } else {
             anari::unsetParameter(device, mat, "color");
+        }
     } else if (hasSolidColor) {
         anari::setParameter(device, mat, "color",
                             anari::std_types::vec4{static_cast<float>(solidColor[0]), static_cast<float>(solidColor[1]),


### PR DESCRIPTION
By:
- Ensuring `m_inTransform` and `m_inOffset` are applied in Image1DSampler (through a new worklet). This is necessary as the ANARI module sets them to values other than the default.
-  Adding the new parameters `m_useValueRange` and `m_valueRange` to the viskores device's Geometry class, so the user can set the range used for the color map themselves (which matches the behavior of the helide device more). This makes it possible to set a global range for a given data field. Before this change, the device would always set the range to the minimum and maximum value in the data field which led to two problems: First, if an isosurface was colored by its input data field, the minimum and maximum of the data field (which itself only contained the isovalue) would be used as range, which could lead to noise in the colors, if there was numerical noise in the isovalues. b) When partitioning the data into multiple blocks, each block would calculate its own range, i.e., its own colormap, which would lead to patchy coloring.

Switching to my viskores fork for now. 