### PR TITLE
Bug fix: Avoid name clash in ANARemote

### DIFF
--- a/module/render/ANARemote/anarirenderobject.cpp
+++ b/module/render/ANARemote/anarirenderobject.cpp
@@ -368,7 +368,7 @@ void AnariRenderObject::create(anari::Device device)
     } else if (useSampler) {
         if (colorMap) {
             anari::setParameter(device, mat, "color", colorMap->sampler);
-            anari::setParameter(device, geom, "useValueRange", true);
+            anari::setParameter(device, geom, "useCustomRangeForTracer", true);
         } else {
             anari::unsetParameter(device, mat, "color");
         }


### PR DESCRIPTION
This bug was introduced in #535.

Problem: The parameter `valueRange` is already used in the derived classes of Geometry, so changed it to `customRangeForTracer` here.