### PR TITLE
Fix depth buffer in Viskores Anari device

### DIFF
--- a/module/render/ANARemote/anaremote.cpp
+++ b/module/render/ANARemote/anaremote.cpp
@@ -623,9 +623,21 @@ bool Anari::render()
         glm::box2 imgRegion;
         offaxisStereoCameraFromTransform(proj.inverse(), mv.inverse(), eye, dir, up, fovy, aspect, imgRegion);
 
+        const glm::vec3 nearPos = glm::unprojectNDC(proj.inverse(), mv.inverse(), glm::vec3(0.f, 0.f, -1.f));
+        float nearPlane = (nearPos - eye).dot(dir);
+        if (!std::isfinite(nearPlane) || nearPlane <= 0.f)
+            nearPlane = 1e-4f;
+
+        const glm::vec3 farPos = glm::unprojectNDC(proj.inverse(), mv.inverse(), glm::vec3(0.f, 0.f, 1.f));
+        float farPlane = (farPos - eye).dot(dir);
+        if (!std::isfinite(farPlane) || farPlane <= nearPlane)
+            farPlane = nearPlane + 1.f;
+
         auto &camera = m_cameras[i];
         anariSetParameter(m_device, camera, "fovy", ANARI_FLOAT32, &fovy);
         anariSetParameter(m_device, camera, "aspect", ANARI_FLOAT32, &aspect);
+        anariSetParameter(m_device, camera, "near", ANARI_FLOAT32, &nearPlane);
+        anariSetParameter(m_device, camera, "far", ANARI_FLOAT32, &farPlane);
         anariSetParameter(m_device, camera, "position", ANARI_FLOAT32_VEC3, &eye[0]);
         anariSetParameter(m_device, camera, "direction", ANARI_FLOAT32_VEC3, &dir[0]);
         anariSetParameter(m_device, camera, "up", ANARI_FLOAT32_VEC3, &up[0]);

--- a/module/render/ANARemote/anaremote.cpp
+++ b/module/render/ANARemote/anaremote.cpp
@@ -654,14 +654,20 @@ bool Anari::render()
                                                  mappedDepth.data, viewport, m_timestep, false);
         } else {
             float *depth = m_renderManager.depth(i);
-            auto mv = m_renderManager.getModelViewMat(i);
-            auto proj = m_renderManager.getProjMat(i);
-            glm::vec3 eye, dir, up;
-            float fovy, aspect;
-            glm::box2 imgRegion;
-            offaxisStereoCameraFromTransform(proj.inverse(), mv.inverse(), eye, dir, up, fovy, aspect, imgRegion);
-            transformDepthFromWorldToGL(mappedDepth.data, depth, eye, dir, up, fovy, aspect, imgRegion, mv, proj,
-                                        mappedDepth.width, mappedDepth.height);
+            const auto lib = m_libraryParam->getValue();
+            if (lib == "viskores") {
+                glm::clampDepthBuffer(mappedDepth.data, depth, mappedDepth.width, mappedDepth.height);
+            } else {
+                auto mv = m_renderManager.getModelViewMat(i);
+                auto proj = m_renderManager.getProjMat(i);
+                glm::vec3 eye, dir, up;
+                float fovy, aspect;
+                glm::box2 imgRegion;
+                glm::offaxisStereoCameraFromTransform(proj.inverse(), mv.inverse(), eye, dir, up, fovy, aspect,
+                                                      imgRegion);
+                glm::transformDepthFromWorldToGL(mappedDepth.data, depth, eye, dir, up, fovy, aspect, imgRegion, mv,
+                                                 proj, mappedDepth.width, mappedDepth.height);
+            }
             m_renderManager.compositeCurrentView(reinterpret_cast<const unsigned char *>(mappedCol.data), depth,
                                                  viewport, m_timestep, false);
         }

--- a/module/render/ANARemote/projection.cpp
+++ b/module/render/ANARemote/projection.cpp
@@ -30,6 +30,7 @@ void transformDepthFromWorldToGL(const float *world, float *gl, vec3 eye, vec3 d
         for (int x = 0; x < width; ++x) {
             size_t index = x + size_t(width) * y;
             float t = world[index];
+
             if (std::isfinite(t)) {
                 float screen_x = vistle::lerp(imageRegion.min[0], imageRegion.max[0], x / (float)width);
 
@@ -47,6 +48,15 @@ void transformDepthFromWorldToGL(const float *world, float *gl, vec3 eye, vec3 d
                 gl[index] = 1.f;
             }
         }
+    }
+}
+
+void clampDepthBuffer(const float *depthBufferIn, float *depthBufferOut, int width, int height)
+{
+    const auto numPixels = size_t(width) * size_t(height);
+    for (size_t index = 0; index < numPixels; ++index) {
+        const float depthIn = depthBufferIn[index];
+        depthBufferOut[index] = std::isfinite(depthIn) ? vistle::clamp<float>(depthIn, 0.f, 1.f) : 1.f;
     }
 }
 

--- a/module/render/ANARemote/projection.h
+++ b/module/render/ANARemote/projection.h
@@ -25,6 +25,8 @@ struct box2 {
 void transformDepthFromWorldToGL(const float *world, float *gl, vec3 eye, vec3 dir, vec3 up, float fovy, float aspect,
                                  box2 imageRegion, mat4 view, mat4 proj, int width, int heigh);
 
+void clampDepthBuffer(const float *depthBufferIn, float *depthBufferOut, int width, int height);
+
 // inlineable functions //
 
 static void offaxisStereoCamera(vec3 LL, vec3 LR, vec3 UR, vec3 eye, vec3 &dirOUT, vec3 &upOUT, float &fovyOUT,


### PR DESCRIPTION
This fix ensures:
- Viskores's depth buffer is already normalized to the window as opposed to the helide device, which is in global space.
- The near and far clipping planes are now passed to the Anari camera before rendering, to make sure depths between Anari and GL can be compared.