### PR TITLE
disable piggy-backed payloads

### DIFF
--- a/lib/vistle/core/CMakeLists.txt
+++ b/lib/vistle/core/CMakeLists.txt
@@ -2,13 +2,13 @@ set(core_SOURCES
     message/colormap.cpp
     message/setname.cpp
     allobjects.cpp # just one file including all the others for faster compilation
-    availablemodule.cpp
     archive_loader.cpp
     archive_saver.cpp
-    archives.cpp
-    archives_compress.cpp
-    archives_compress_sz3.cpp
     archives_compress_bigwhoop.cpp
+    archives_compress_sz3.cpp
+    archives_compress.cpp
+    archives.cpp
+    availablemodule.cpp
     cellalgorithm.cpp
     filequery.cpp
     geometry.cpp
@@ -25,10 +25,10 @@ set(core_SOURCES
     paramvector.cpp
     port.cpp
     porttracker.cpp
-    shm.cpp
     shm_array.cpp
     shm_obj_ref.cpp
     shm_reference.cpp
+    shm.cpp
     shmname.cpp
     statetracker.cpp
     tcpmessage.cpp
@@ -62,108 +62,108 @@ set(core_SOURCES
     vertexownerlist.cpp)
 
 set(core_HEADERS
-    message/colormap.h
-    message/setname.h
     archive_loader.h
     archive_saver.h
-    archives.h
-    archives_compress.h
-    archives_compress_sz3.h
     archives_compress_bigwhoop.h
+    archives_compress_sz3.h
+    archives_compress.h
     archives_config.h
     archives_impl.h
+    archives.h
     availablemodule.h
     cellalgorithm.h
-    celltree.h
     celltree_impl.h
-    celltreenode.h
+    celltree.h
     celltreenode_decl.h
+    celltreenode.h
     celltypes.h
-    coords.h
     coords_impl.h
-    database.h
+    coords.h
     database_impl.h
+    database.h
     dimensions.h
-    empty.h
     empty_impl.h
+    empty.h
     export.h
     filequery.h
     geometry.h
     grid.h
     index.h
-    indexed.h
     indexed_impl.h
-    layergrid.h
+    indexed.h
     layergrid_impl.h
-    lines.h
+    layergrid.h
     lines_impl.h
+    lines.h
     message.h
+    message/colormap.h
+    message/setname.h
     messagepayload.h
     messagepayloadtemplates.h
     messagequeue.h
     messagerouter.h
     messages.h
     messagesender.h
-    ngons.h
     ngons_impl.h
-    normals.h
+    ngons.h
     normals_impl.h
-    object.h
+    normals.h
     object_impl.h
-    objectmeta.h
+    object.h
     objectmeta_impl.h
+    objectmeta.h
     parameter.h
-    parametermanager.h
     parametermanager_impl.h
-    paramvector.h
+    parametermanager.h
     paramvector_impl.h
-    placeholder.h
+    paramvector.h
     placeholder_impl.h
-    points.h
+    placeholder.h
     points_impl.h
-    polygons.h
+    points.h
     polygons_impl.h
+    polygons.h
     port.h
     porttracker.h
     quads.h
-    rectilineargrid.h
     rectilineargrid_impl.h
+    rectilineargrid.h
     rgba.h
     scalar.h
     scalars.h
     serialize.h
-    shm.h
-    shm_array.h
     shm_array_impl.h
+    shm_array.h
     shm_config.h
     shm_impl.h
-    shm_obj_ref.h
     shm_obj_ref_impl.h
-    shm_reference.h
+    shm_obj_ref.h
     shm_reference_impl.h
+    shm_reference.h
+    shm.h
     shmdata.h
     shmname.h
     shmvector.h
     statetracker.h
-    structuredgrid.h
     structuredgrid_impl.h
-    structuredgridbase.h
+    structuredgrid.h
     structuredgridbase_impl.h
+    structuredgridbase.h
     tcpmessage.h
     triangles.h
-    uniformgrid.h
     uniformgrid_impl.h
-    unstr.h
+    uniformgrid.h
     unstr_geo.h
     unstr_impl.h
+    unstr.h
     uuid.h
-    vec.h
     vec_impl.h
     vec_template.h
+    vec.h
     vector.h
     vectortypes.h
-    vertexownerlist.h
-    vertexownerlist_impl.h)
+    vertexownerlist_impl.h
+    vertexownerlist.h)
 
 if(MSVC)
     set_source_files_properties(allobjects.cpp PROPERTIES COMPILE_FLAGS /bigobj)

--- a/lib/vistle/core/CMakeLists.txt
+++ b/lib/vistle/core/CMakeLists.txt
@@ -10,6 +10,7 @@ set(core_SOURCES
     archives.cpp
     availablemodule.cpp
     cellalgorithm.cpp
+    envelope.cpp
     filequery.cpp
     geometry.cpp
     message.cpp
@@ -25,6 +26,7 @@ set(core_SOURCES
     port.cpp
     porttracker.cpp
     shm_array.cpp
+    shmenvelope.cpp
     shm_obj_ref.cpp
     shm_reference.cpp
     shm.cpp
@@ -83,6 +85,7 @@ set(core_HEADERS
     dimensions.h
     empty_impl.h
     empty.h
+    envelope.h
     export.h
     filequery.h
     geometry.h
@@ -134,6 +137,7 @@ set(core_HEADERS
     shm_array_impl.h
     shm_array.h
     shm_config.h
+    shmenvelope.h
     shm_impl.h
     shm_obj_ref_impl.h
     shm_obj_ref.h

--- a/lib/vistle/core/CMakeLists.txt
+++ b/lib/vistle/core/CMakeLists.txt
@@ -13,7 +13,6 @@ set(core_SOURCES
     filequery.cpp
     geometry.cpp
     message.cpp
-    messagepayload.cpp
     messagequeue.cpp
     messagerouter.cpp
     messages.cpp

--- a/lib/vistle/core/envelope.cpp
+++ b/lib/vistle/core/envelope.cpp
@@ -1,0 +1,141 @@
+#include "envelope.h"
+#include "message.h"
+
+namespace vistle {
+namespace message {
+
+Envelope::Envelope(const message::Message &msg): m_message(msg)
+{
+    assert(msg.payloadSize() == 0);
+}
+
+Envelope::Envelope(const message::Message &msg, const char *payload, size_t payloadSize): m_message(msg)
+{
+    m_internalPayload = m_message.addPayload(payload, payloadSize);
+    m_message.setPayloadSize(payloadSize);
+}
+
+Envelope::Envelope(const message::Buffer &msg): m_message(msg), m_internalPayload(m_message.getPayload())
+{}
+
+std::unique_ptr<Envelope> Envelope::clone() const
+{
+    return std::make_unique<Envelope>(this->m_message);
+}
+
+Envelope::Envelope(const Envelope &other): m_message(other.m_message)
+{
+    m_internalPayload = m_message.getPayload();
+}
+
+Envelope &Envelope::operator=(const Envelope &other)
+{
+    if (this != &other) {
+        m_message = other.m_message;
+        m_internalPayload = m_message.getPayload();
+    }
+    return *this;
+}
+
+void Envelope::updateMessage()
+{
+    if (m_message.payloadSize() == 0)
+        return;
+    m_internalPayload = m_message.getPayload();
+}
+
+buffer Envelope::copyPayload() const
+{
+    if (payloadSize() == 0) {
+        return buffer();
+    }
+    return buffer(payloadData(), payloadData() + payloadSize());
+}
+
+const char *Envelope::payloadData() const
+{
+    if (m_message.payloadSize() == 0) {
+        return nullptr;
+    }
+    assert(m_internalPayload || getExternalPayload());
+
+    return m_internalPayload ? m_internalPayload : getExternalPayload();
+}
+
+size_t Envelope::headerSize() const
+{
+    return m_message.size() + (m_internalPayload ? m_message.payloadSize() : 0);
+}
+
+size_t Envelope::externalPayloadSize() const
+{
+    return m_internalPayload ? 0 : payloadSize();
+}
+
+message::Buffer &Envelope::message()
+{
+    return m_message;
+}
+
+const message::Buffer &Envelope::message() const
+{
+    return m_message;
+}
+
+bool Envelope::hasInternalPayload() const
+{
+    return m_internalPayload;
+}
+
+size_t Envelope::payloadSize() const
+{
+    assert(m_message.payloadSize() == 0 || m_internalPayload || getExternalPayload());
+    return m_message.payloadSize();
+}
+
+const char *Envelope::getExternalPayload() const
+{
+    return m_internalPayload;
+}
+
+
+BufferEnvelope::BufferEnvelope(const message::Message &msg, const vistle::buffer &payload)
+: Envelope(msg, payload.data(), payload.size())
+{
+    if (!m_internalPayload) {
+        m_payload = std::make_shared<vistle::buffer>(payload);
+        m_message.setPayloadSize(payload.size());
+    }
+}
+
+BufferEnvelope::BufferEnvelope(const message::Message &msg, std::shared_ptr<vistle::buffer> payload)
+: Envelope(msg, payload->data(), payload->size())
+{
+    if (!m_internalPayload) {
+        m_payload = payload;
+        m_message.setPayloadSize(payload->size());
+    }
+}
+
+std::unique_ptr<Envelope> BufferEnvelope::clone() const
+{
+    return std::make_unique<BufferEnvelope>(*this);
+}
+
+const char *BufferEnvelope::getExternalPayload() const
+{
+    return m_payload ? m_payload->data() : nullptr;
+}
+
+const std::shared_ptr<vistle::buffer> &BufferEnvelope::bufferPayload() const
+{
+    return m_payload;
+}
+
+std::shared_ptr<vistle::buffer> &BufferEnvelope::bufferPayload()
+{
+    return m_payload;
+}
+
+} // namespace message
+} // namespace vistle

--- a/lib/vistle/core/envelope.h
+++ b/lib/vistle/core/envelope.h
@@ -1,0 +1,85 @@
+#ifndef VISTLE_CORE_ENVELOPE_H
+#define VISTLE_CORE_ENVELOPE_H
+
+#include "export.h"
+#include <vector>
+#include "message.h"
+#include <vistle/util/buffer.h>
+namespace vistle {
+
+namespace message {
+class V_COREEXPORT Envelope {
+public:
+    Envelope() = default; //set buffer() manually and use updatePayload() to eventually get shm/internal payload
+    Envelope(const message::Message &msg); // MessagePayload without payload
+    Envelope(const message::Buffer &msg); // overload for Buffer so that it can be copied with its full payload
+
+    virtual ~Envelope() = default;
+    virtual std::unique_ptr<Envelope> clone() const;
+
+    message::Buffer &message();
+    const message::Buffer &message() const;
+
+    const char *payloadData() const;
+    size_t payloadSize() const;
+    buffer copyPayload() const;
+
+
+    size_t headerSize() const; // message + eventual internal payload size
+    size_t externalPayloadSize() const;
+    bool hasInternalPayload() const;
+
+    // use to set m_internalPayload after Buffer is read from a stream
+    void updateMessage();
+
+    template<typename SomeMessage>
+    SomeMessage &as()
+    {
+        return m_message.as<SomeMessage>();
+    }
+
+    template<typename SomeMessage>
+    const SomeMessage &as() const
+    {
+        return m_message.as<SomeMessage>();
+    }
+
+    // save a copy if we already have a payload as buffer
+    // todo: change the archive functions so that they can work on other arrays
+    template<typename Payload>
+    Payload deserializePayload() const
+    {
+        assert(payloadSize() > 0);
+        return message::getPayload<Payload>({payloadData(), payloadData() + payloadSize()});
+    }
+
+protected:
+    Envelope(const Envelope &other);
+    Envelope &operator=(const Envelope &other);
+    Envelope(const message::Message &msg, const char *payload, size_t payloadSize);
+
+    virtual const char *getExternalPayload() const;
+
+    // keep m_buffer first
+    message::Buffer m_message;
+    const char *m_internalPayload = nullptr;
+};
+
+class V_COREEXPORT BufferEnvelope: public Envelope {
+public:
+    using Envelope::Envelope;
+    BufferEnvelope(const message::Message &msg, const vistle::buffer &payload); // copy payload to buffer
+    BufferEnvelope(const message::Message &msg,
+                   std::shared_ptr<vistle::buffer> payload); // use existing buffer as payload
+    std::unique_ptr<Envelope> clone() const override;
+    const std::shared_ptr<vistle::buffer> &bufferPayload() const;
+    std::shared_ptr<vistle::buffer> &bufferPayload();
+
+private:
+    const char *getExternalPayload() const override;
+    std::shared_ptr<vistle::buffer> m_payload;
+};
+
+} // namespace message
+} // namespace vistle
+#endif

--- a/lib/vistle/core/message.cpp
+++ b/lib/vistle/core/message.cpp
@@ -126,6 +126,34 @@ codec_error::codec_error(const std::string &what): vistle::exception(what)
 
 DefaultSender DefaultSender::s_instance;
 
+const char *Buffer::addPayload(const char *data, size_t size)
+{
+    if (!data || size == 0)
+        return nullptr;
+    size_t head = this->size() - sizeof(Message); // current used bytes in payload[]
+    if (size > payload.size() - head) {
+        // std::cerr << "Buffer::addPayload: payload too large for " << message::toString(type()) << ": " << size
+        //   << " > " << (payload.size() - head) << std::endl;
+        return nullptr;
+    }
+    // std::cerr << "Buffer::addPayload: copy payload for " << message::toString(type()) << ": " << size << " < "
+    //   << (payload.size() - head) << std::endl;
+    setPayloadSize(size);
+#ifndef NDEBUG
+    setPayloadName(shm_name_t("includedPayload"));
+#endif
+    memcpy(payload.data() + head, data, size);
+    return payload.data() + head;
+}
+
+const char *Buffer::getPayload() const
+{
+    if (!payloadSize() || size() + payloadSize() > bufferSize())
+        return nullptr;
+    assert(payloadName() == shm_name_t("includedPayload"));
+    return payload.data() + size() - sizeof(Message);
+}
+
 DefaultSender::DefaultSender(): m_id(Id::Invalid), m_rank(-1)
 {
     Router::the();

--- a/lib/vistle/core/message.h
+++ b/lib/vistle/core/message.h
@@ -314,12 +314,8 @@ public:
         memset(payload.data(), 0, payload.size());
         memcpy(payload.data(), (char *)&message + sizeof(Message), message.size() - sizeof(Message));
     }
-    const Buffer &operator=(const Buffer &rhs)
-    {
-        *static_cast<Message *>(this) = rhs;
-        memcpy(payload.data(), rhs.payload.data(), payload.size());
-        return *this;
-    }
+
+    Buffer(const Buffer &message) = default;
 
     template<class SomeMessage>
     SomeMessage &as()
@@ -335,9 +331,9 @@ public:
         assert(m->type() == SomeMessage::s_type);
         return *m;
     }
-
-    size_t bufferSize() const { return Message::MESSAGE_SIZE; }
-    size_t size() const { return Message::size(); }
+    const char *addPayload(const char *data, size_t size);
+    const char *getPayload() const;
+    static size_t bufferSize() { return Message::MESSAGE_SIZE; }
     char *data() { return static_cast<char *>(static_cast<void *>(this)); }
     const char *data() const { return static_cast<const char *>(static_cast<const void *>(this)); }
 
@@ -362,6 +358,12 @@ template<class Payload>
 extern V_COREEXPORT buffer addPayload(Message &message, const Payload &payload);
 template<class Payload>
 extern V_COREEXPORT Payload getPayload(const buffer &data);
+template<class Payload>
+Payload getPayload(const char *data, size_t size)
+{
+    // todo: dont copy the data
+    return getPayload<Payload>(vistle::buffer(data, data + size));
+}
 
 V_COREEXPORT buffer compressPayload(vistle::message::CompressionMode &mode, const char *raw, size_t size,
                                     int speed = -1 /* algorithm default */);

--- a/lib/vistle/core/messagepayload.cpp
+++ b/lib/vistle/core/messagepayload.cpp
@@ -1,3 +1,0 @@
-#include "messagepayload.h"
-
-namespace vistle {}

--- a/lib/vistle/core/shmenvelope.cpp
+++ b/lib/vistle/core/shmenvelope.cpp
@@ -1,0 +1,64 @@
+#include "shmenvelope.h"
+
+using namespace vistle;
+
+ShmEnvelope::ShmEnvelope(const message::Message &msg, const vistle::buffer &payload)
+: Envelope(msg, payload.data(), payload.size())
+{
+    if (!m_internalPayload) {
+        m_payload = MessagePayload(payload.data(), payload.size());
+        m_message.setPayloadName(m_payload.name());
+        m_message.setPayloadSize(payload.size());
+    }
+}
+
+ShmEnvelope::ShmEnvelope(const message::Message &msg, const MessagePayload &payload)
+: Envelope(msg, payload->data(), payload->size())
+{
+    if (!m_internalPayload && payload->size() > 0) {
+        m_payload = payload;
+        m_message.setPayloadName(m_payload.name());
+        m_message.setPayloadSize(payload->size());
+    }
+}
+
+std::unique_ptr<message::Envelope> ShmEnvelope::clone() const
+{
+    return std::make_unique<ShmEnvelope>(*this);
+}
+
+void ShmEnvelope::ref() const
+{
+    if (m_payload) {
+        const_cast<MessagePayload &>(m_payload).ref();
+    }
+}
+
+void ShmEnvelope::unref() const
+{
+    if (m_payload) {
+        const_cast<MessagePayload &>(m_payload).unref();
+    }
+}
+
+const char *ShmEnvelope::getExternalPayload() const
+{
+    return m_payload ? m_payload->data() : nullptr;
+}
+
+void ShmEnvelope::getPayloadFromHeader()
+{
+    assert(!m_payload);
+    m_payload = Shm::the().getArrayFromName<char>(m_message.payloadName());
+    assert(m_payload);
+}
+
+const MessagePayload &ShmEnvelope::shmPayload() const
+{
+    return m_payload;
+}
+
+MessagePayload &ShmEnvelope::shmPayload()
+{
+    return m_payload;
+}

--- a/lib/vistle/core/shmenvelope.h
+++ b/lib/vistle/core/shmenvelope.h
@@ -1,0 +1,31 @@
+#ifndef VISTLE_CORE_SHMENVELOPE_H
+#define VISTLE_CORE_SHMENVELOPE_H
+
+#include "envelope.h"
+#include "export.h"
+#include "message.h"
+#include "messagepayload.h"
+namespace vistle {
+class V_COREEXPORT ShmEnvelope: public message::Envelope {
+public:
+    using Envelope::Envelope;
+    ShmEnvelope(const message::Message &msg, const vistle::buffer &payload); // copy payload to shm
+    ShmEnvelope(const message::Message &msg, const MessagePayload &payload); // use existing buffer as payload
+    std::unique_ptr<Envelope> clone() const override;
+
+    // increase reference count of payload in shared memory
+    // mandatory before sending for each reciepient, otherwise the payload will be deleted when it goes out of scope
+    void ref() const;
+    // decrease when receiving a message with a payload in shared memory, otherwise the payload will never be deleted
+    void unref() const;
+    void getPayloadFromHeader();
+    const MessagePayload &shmPayload() const;
+    MessagePayload &shmPayload();
+
+private:
+    const char *getExternalPayload() const override;
+    MessagePayload m_payload;
+};
+} // namespace vistle
+
+#endif


### PR DESCRIPTION
for now, retain compatibility with older versions